### PR TITLE
Feature/BDN-816 Stabilize SDK for Unity Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.7.1-next.1
+## Features:
+- [BDN-816](https://appodeal.atlassian.net/browse/BDN-816) Stabilized SDK for Unity plugin
+
 # 0.7.0
 ## Promoted the beta release to the stable version
 

--- a/adapter/amazon/src/main/java/org/bidon/amazon/AmazonBidManager.kt
+++ b/adapter/amazon/src/main/java/org/bidon/amazon/AmazonBidManager.kt
@@ -72,10 +72,12 @@ internal class AmazonBidManager {
 
         return JSONArray().apply {
             amazonInfo.forEach { (slotUuid, dtbAdResponse) ->
-                put(JSONObject().apply {
-                    put("slot_uuid", slotUuid)
-                    put("price_point", SDKUtilities.getPricePoint(dtbAdResponse))
-                })
+                put(
+                    JSONObject().apply {
+                        put("slot_uuid", slotUuid)
+                        put("price_point", SDKUtilities.getPricePoint(dtbAdResponse))
+                    }
+                )
             }
         }.toString()
     }

--- a/adapter/bigoads/src/main/java/org/bidon/bigoads/impl/BigoAdsBannerImpl.kt
+++ b/adapter/bigoads/src/main/java/org/bidon/bigoads/impl/BigoAdsBannerImpl.kt
@@ -38,7 +38,7 @@ internal class BigoAdsBannerImpl :
     private var bannerSize: AdSize? = null
 
     override val isAdReadyToShow: Boolean
-        get() = bannerAd != null && bannerAd?.isExpired == false && bannerAd?.adView() != null
+        get() = bannerAd?.isExpired == false
 
     override fun getAuctionParam(auctionParamsScope: AdAuctionParamSource): Result<AdAuctionParams> {
         return auctionParamsScope {

--- a/adapter/bigoads/src/main/java/org/bidon/bigoads/impl/BigoAdsInterstitialImpl.kt
+++ b/adapter/bigoads/src/main/java/org/bidon/bigoads/impl/BigoAdsInterstitialImpl.kt
@@ -34,7 +34,7 @@ internal class BigoAdsInterstitialImpl :
     private var interstitialAd: InterstitialAd? = null
 
     override val isAdReadyToShow: Boolean
-        get() = interstitialAd != null && interstitialAd?.isExpired == false
+        get() = interstitialAd?.isExpired == false
 
     override fun getAuctionParam(auctionParamsScope: AdAuctionParamSource): Result<AdAuctionParams> {
         return auctionParamsScope {

--- a/adapter/bigoads/src/main/java/org/bidon/bigoads/impl/BigoAdsInterstitialImpl.kt
+++ b/adapter/bigoads/src/main/java/org/bidon/bigoads/impl/BigoAdsInterstitialImpl.kt
@@ -34,7 +34,7 @@ internal class BigoAdsInterstitialImpl :
     private var interstitialAd: InterstitialAd? = null
 
     override val isAdReadyToShow: Boolean
-        get() = interstitialAd != null && interstitialAd?.isExpired != false
+        get() = interstitialAd != null && interstitialAd?.isExpired == false
 
     override fun getAuctionParam(auctionParamsScope: AdAuctionParamSource): Result<AdAuctionParams> {
         return auctionParamsScope {

--- a/adapter/bigoads/src/main/java/org/bidon/bigoads/impl/BigoAdsRewardedAdImpl.kt
+++ b/adapter/bigoads/src/main/java/org/bidon/bigoads/impl/BigoAdsRewardedAdImpl.kt
@@ -34,7 +34,7 @@ internal class BigoAdsRewardedAdImpl :
     private var rewardVideoAd: RewardVideoAd? = null
 
     override val isAdReadyToShow: Boolean
-        get() = rewardVideoAd != null && rewardVideoAd?.isExpired == false
+        get() = rewardVideoAd?.isExpired == false
 
     override fun getAuctionParam(auctionParamsScope: AdAuctionParamSource): Result<AdAuctionParams> {
         return auctionParamsScope {

--- a/adapter/bigoads/src/main/java/org/bidon/bigoads/impl/BigoAdsRewardedAdImpl.kt
+++ b/adapter/bigoads/src/main/java/org/bidon/bigoads/impl/BigoAdsRewardedAdImpl.kt
@@ -34,7 +34,7 @@ internal class BigoAdsRewardedAdImpl :
     private var rewardVideoAd: RewardVideoAd? = null
 
     override val isAdReadyToShow: Boolean
-        get() = rewardVideoAd != null && rewardVideoAd?.isExpired != false
+        get() = rewardVideoAd != null && rewardVideoAd?.isExpired == false
 
     override fun getAuctionParam(auctionParamsScope: AdAuctionParamSource): Result<AdAuctionParams> {
         return auctionParamsScope {

--- a/adapter/vungle/src/main/java/org/bidon/vungle/impl/VungleBannerImpl.kt
+++ b/adapter/vungle/src/main/java/org/bidon/vungle/impl/VungleBannerImpl.kt
@@ -32,7 +32,7 @@ internal class VungleBannerImpl :
     private var banner: BannerAd? = null
 
     override val isAdReadyToShow: Boolean
-        get() = banner?.getBannerView() != null
+        get() = banner?.canPlayAd() == true
 
     override fun getAuctionParam(auctionParamsScope: AdAuctionParamSource): Result<AdAuctionParams> {
         return auctionParamsScope {

--- a/bidon/src/main/java/org/bidon/sdk/ads/banner/BannerManager.kt
+++ b/bidon/src/main/java/org/bidon/sdk/ads/banner/BannerManager.kt
@@ -96,7 +96,7 @@ class BannerManager private constructor(
         _bannerFormat = bannerFormat
     }
 
-    override fun loadAd(activity: Activity, pricefloor: Double) {
+    override fun loadAd(activity: Activity, pricefloor: Double, auctionKey: String?) {
         activity.runOnUiThread {
             weakActivity = WeakReference(activity)
             if (!BidonSdk.isInitialized()) {
@@ -120,6 +120,7 @@ class BannerManager private constructor(
                 activity = activity,
                 format = bannerFormat,
                 pricefloor = pricefloor,
+                auctionKey = auctionKey,
                 extras = extras,
                 onLoaded = { ad, auctionInfo, bannerView ->
                     this.nextBannerView = bannerView

--- a/bidon/src/main/java/org/bidon/sdk/ads/banner/BannerManager.kt
+++ b/bidon/src/main/java/org/bidon/sdk/ads/banner/BannerManager.kt
@@ -26,13 +26,16 @@ import java.util.concurrent.atomic.AtomicBoolean
  */
 class BannerManager private constructor(
     private val bannersCache: BannersCache,
-    private val extras: Extras
+    private val extras: Extras,
+    private val auctionKey: String? = null,
 ) : PositionedBanner,
     Extras {
 
-    constructor() : this(
+    @JvmOverloads
+    constructor(auctionKey: String? = null) : this(
         bannersCache = BannersCacheImpl(),
-        extras = ExtrasImpl()
+        extras = ExtrasImpl(),
+        auctionKey = auctionKey,
     ) {
         logInfo(tag, "Created $this")
     }
@@ -96,7 +99,7 @@ class BannerManager private constructor(
         _bannerFormat = bannerFormat
     }
 
-    override fun loadAd(activity: Activity, pricefloor: Double, auctionKey: String?) {
+    override fun loadAd(activity: Activity, pricefloor: Double) {
         activity.runOnUiThread {
             weakActivity = WeakReference(activity)
             if (!BidonSdk.isInitialized()) {

--- a/bidon/src/main/java/org/bidon/sdk/ads/banner/PositionedBanner.kt
+++ b/bidon/src/main/java/org/bidon/sdk/ads/banner/PositionedBanner.kt
@@ -46,7 +46,7 @@ interface PositionedBanner {
     )
 
     fun setBannerFormat(bannerFormat: BannerFormat)
-    fun loadAd(activity: Activity, pricefloor: Double = BidonSdk.DefaultPricefloor)
+    fun loadAd(activity: Activity, pricefloor: Double = BidonSdk.DefaultPricefloor, auctionKey: String? = null)
 
     /**
      * Shows if banner is ready to show

--- a/bidon/src/main/java/org/bidon/sdk/ads/banner/PositionedBanner.kt
+++ b/bidon/src/main/java/org/bidon/sdk/ads/banner/PositionedBanner.kt
@@ -46,7 +46,7 @@ interface PositionedBanner {
     )
 
     fun setBannerFormat(bannerFormat: BannerFormat)
-    fun loadAd(activity: Activity, pricefloor: Double = BidonSdk.DefaultPricefloor, auctionKey: String? = null)
+    fun loadAd(activity: Activity, pricefloor: Double = BidonSdk.DefaultPricefloor)
 
     /**
      * Shows if banner is ready to show

--- a/bidon/src/main/java/org/bidon/sdk/ads/banner/refresh/BannersCache.kt
+++ b/bidon/src/main/java/org/bidon/sdk/ads/banner/refresh/BannersCache.kt
@@ -25,6 +25,7 @@ internal interface BannersCache {
         activity: Activity,
         format: BannerFormat,
         pricefloor: Double,
+        auctionKey: String?,
         extras: Extras,
         onLoaded: (Ad, AuctionInfo, BannerView) -> Unit,
         onFailed: (AuctionInfo?, BidonError) -> Unit,
@@ -45,6 +46,7 @@ internal class BannersCacheImpl : BannersCache {
         activity: Activity,
         format: BannerFormat,
         pricefloor: Double,
+        auctionKey: String?,
         extras: Extras,
         onLoaded: (Ad, AuctionInfo, BannerView) -> Unit,
         onFailed: (AuctionInfo?, BidonError) -> Unit,
@@ -56,7 +58,10 @@ internal class BannersCacheImpl : BannersCache {
         }
         if (!isLoading.getAndSet(true)) {
             activity.runOnUiThread {
-                val banner = BannerView(activity.applicationContext)
+                val banner = BannerView(
+                    context = activity.applicationContext,
+                    auctionKey = auctionKey
+                )
                 banner.setExtras(extras)
                 banner.setBannerFormat(format)
                 banner.setBannerListener(object : BannerListener {


### PR DESCRIPTION
https://appodeal.atlassian.net/browse/BDN-816


This pull request includes several changes to improve the stability and functionality of the ad SDK, particularly focusing on the handling of banner ads and interstitial ads. The most important changes include updating the `isAdReadyToShow` logic for various ad implementations, adding an `auctionKey` parameter to banner ad loading methods, and stabilizing the SDK for the Unity plugin.

### Improvements to ad readiness checks:
* [`adapter/bigoads/src/main/java/org/bidon/bigoads/impl/BigoAdsInterstitialImpl.kt`](diffhunk://#diff-3c00d0c9f7bd03afae7f05bcd2d2fb6ce0e8526ffeccc295f3c3c0e32c6938d6L37-R37): Updated the `isAdReadyToShow` logic to check if `interstitialAd?.isExpired` is `false` instead of `!= false`.
* [`adapter/bigoads/src/main/java/org/bidon/bigoads/impl/BigoAdsRewardedAdImpl.kt`](diffhunk://#diff-90b20dc9142b4541f110b8b12be4939db58f9649321c2e70000dcc2a85308246L37-R37): Updated the `isAdReadyToShow` logic to check if `rewardVideoAd?.isExpired` is `false` instead of `!= false`.
* [`adapter/vungle/src/main/java/org/bidon/vungle/impl/VungleBannerImpl.kt`](diffhunk://#diff-e3d7de6c32ef5abbe79953832f238bdad8031fbfd76ee59f64fb0dd30549a828L35-R35): Updated the `isAdReadyToShow` logic to check if `banner?.canPlayAd()` is `true` instead of checking if `banner?.getBannerView()` is not `null`.

### Addition of auctionKey parameter:
* [`bidon/src/main/java/org/bidon/sdk/ads/banner/BannerManager.kt`](diffhunk://#diff-5bff639ea6e5502c8346d1f51904240d77dd3738bc4acc907f6097a9c79e4780L99-R99): Added `auctionKey` parameter to the `loadAd` method and updated its usage within the method. [[1]](diffhunk://#diff-5bff639ea6e5502c8346d1f51904240d77dd3738bc4acc907f6097a9c79e4780L99-R99) [[2]](diffhunk://#diff-5bff639ea6e5502c8346d1f51904240d77dd3738bc4acc907f6097a9c79e4780R123)
* [`bidon/src/main/java/org/bidon/sdk/ads/banner/PositionedBanner.kt`](diffhunk://#diff-bc9d8b8d26c8d30784b9f7dd53b8318d9ea66cf531039263d1e621a26986b7f8L49-R49): Added `auctionKey` parameter to the `loadAd` method with a default value of `null`.
* [`bidon/src/main/java/org/bidon/sdk/ads/banner/refresh/BannersCache.kt`](diffhunk://#diff-c8104bd83171f1f9ed82044345115ccf5f962f5690c45bef340e8ddaf30800c1R28): Added `auctionKey` parameter to the `loadAd` method and updated its usage within the method. [[1]](diffhunk://#diff-c8104bd83171f1f9ed82044345115ccf5f962f5690c45bef340e8ddaf30800c1R28) [[2]](diffhunk://#diff-c8104bd83171f1f9ed82044345115ccf5f962f5690c45bef340e8ddaf30800c1R49) [[3]](diffhunk://#diff-c8104bd83171f1f9ed82044345115ccf5f962f5690c45bef340e8ddaf30800c1L59-R64)

### SDK stabilization:
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R4): Documented the stabilization of the SDK for the Unity plugin under the new version `0.7.1-next.1`.