### PR TITLE
Feature/BDN-873: Standardized timestamp logic for stats requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# develop
+## Features:
+- [BDN-873](https://appodeal.atlassian.net/browse/BDN-873) Standardized timestamp logic for stats requests
+
 # 0.7.1
 ## Features:
 - [BDN-799](https://appodeal.atlassian.net/browse/BDN-799) Updated Admob/Gam to 23.5.0

--- a/bidon/src/main/java/org/bidon/sdk/auction/impl/AuctionImpl.kt
+++ b/bidon/src/main/java/org/bidon/sdk/auction/impl/AuctionImpl.kt
@@ -76,15 +76,16 @@ internal class AuctionImpl(
                     resultsCollector.startRound(adTypeParam.pricefloor)
                     resultsCollector.serverBiddingStarted()
 
+                    // Request for Auction-data at /auction
+                    val auctionId = UUID.randomUUID().toString()
+                    auctionStat.markAuctionStarted(auctionId, adTypeParam)
+
                     val tokens = getTokens(
                         adTypeParam = adTypeParam,
                         adaptersSource = adaptersSource,
                         tokenTimeout = biddingConfig.tokenTimeout
                     )
 
-                    // Request for Auction-data at /auction
-                    val auctionId = UUID.randomUUID().toString()
-                    auctionStat.markAuctionStarted(auctionId, adTypeParam)
                     getAuctionRequest.request(
                         adTypeParam = adTypeParam,
                         auctionId = auctionId,


### PR DESCRIPTION
https://appodeal.atlassian.net/browse/BDN-873

This pull request includes updates to the `CHANGELOG.md` file and a small refactoring in the `AuctionImpl` class within the `bidon` module. The changes aim to standardize timestamp logic for stats requests and improve the code structure.

### Updates to documentation:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R4): Added a new feature entry for the standardized timestamp logic for stats requests under the develop section.

### Code refactoring:

* [`bidon/src/main/java/org/bidon/sdk/auction/impl/AuctionImpl.kt`](diffhunk://#diff-bfe205b9f227343dd30a37d23390c706cad4946f6049dc007065cca4f7706c2fR79-L87): Moved the auction ID generation and auction start marking code to occur before token retrieval to improve the logical flow of the auction process.