### PR TITLE
Feature/BDN-840: Synchronize public api for Unity plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Develop
+## Features:
+- [BDN-840](https://appodeal.atlassian.net/browse/BDN-840) Synchronize public api for Unity plugin
+
 # 0.7.2
 ## Features:
 - [BDN-877](https://appodeal.atlassian.net/browse/BDN-877) Updated DtExchange to 8.3.5

--- a/adapter/appsflyer/src/main/java/org/bidon/appsflyer/AppsflyerAnalytics.kt
+++ b/adapter/appsflyer/src/main/java/org/bidon/appsflyer/AppsflyerAnalytics.kt
@@ -63,7 +63,7 @@ class AppsflyerAnalytics : Adapter, Initializable<AppsflyerParameters>, AdRevenu
             this["auction_round"] = ad.roundId
         }
         val monetizationNetwork = ad.networkName ?: "unknown"
-        val eventRevenue = ad.ecpm
+        val eventRevenue = ad.price
         val eventRevenueCurrency = ad.currency ?: Currency.getInstance("USD")
 
         AppsFlyerAdRevenue.logAdRevenue(

--- a/adapter/fyber/src/main/java/org/bidon/fyber/FairBidAdapter.kt
+++ b/adapter/fyber/src/main/java/org/bidon/fyber/FairBidAdapter.kt
@@ -69,7 +69,7 @@ internal class FairBidAdapter :
             currencyCode = this?.currency,
             auctionId = "",
             adUnitId = null,
-            ecpm = this?.netPayout ?: 0.0,
+            price = this?.netPayout ?: 0.0,
         )
     }
 

--- a/app/src/main/java/org/bidon/demoapp/JavaMainActivity.java
+++ b/app/src/main/java/org/bidon/demoapp/JavaMainActivity.java
@@ -63,7 +63,7 @@ public class JavaMainActivity extends AppCompatActivity {
 
             @Override
             public void onRevenuePaid(@NonNull Ad ad, @NonNull AdValue adValue) {
-                double a = ad.getEcpm();
+                double a = ad.getPrice();
                 adValue.getAdRevenue();
                 adValue.getCurrency();
                 adValue.getPrecision();

--- a/app/src/main/java/org/bidon/demoapp/ui/BannerScreen.kt
+++ b/app/src/main/java/org/bidon/demoapp/ui/BannerScreen.kt
@@ -209,7 +209,7 @@ fun BannerScreen(navController: NavHostController) {
             Row {
                 AppTextButton(text = "Notify Loss") {
                     bannerView?.also {
-                        it.notifyLoss(winnerDemandId = "Unity", winnerEcpm = 4.0)
+                        it.notifyLoss(winnerDemandId = "Unity", winnerPrice = 4.0)
                         logFlow.log("NotifyLoss")
                     }
                 }

--- a/app/src/main/java/org/bidon/demoapp/ui/InterstitialScreen.kt
+++ b/app/src/main/java/org/bidon/demoapp/ui/InterstitialScreen.kt
@@ -171,7 +171,7 @@ fun InterstitialScreen(
                 ) {
                     interstitial.notifyLoss(
                         winnerDemandId = "som_winner_demand",
-                        winnerEcpm = 234.567
+                        winnerPrice = 234.567
                     )
                     logFlow.log("NotifyLoss")
                 }

--- a/app/src/main/java/org/bidon/demoapp/ui/RewardedScreen.kt
+++ b/app/src/main/java/org/bidon/demoapp/ui/RewardedScreen.kt
@@ -166,7 +166,7 @@ fun RewardedScreen(
                 ) {
                     rewardedAd.notifyLoss(
                         winnerDemandId = "some_winner_demand",
-                        winnerEcpm = 123.456
+                        winnerPrice = 123.456
                     )
                     logFlow.log("NotifyLoss")
                 }

--- a/app/src/main/java/org/bidon/demoapp/ui/ext/Ext.kt
+++ b/app/src/main/java/org/bidon/demoapp/ui/ext/Ext.kt
@@ -58,7 +58,6 @@ fun AdUnitInfo.toJson(): String {
                 "fill_start_ts": $fillStartTs,
                 "fill_finish_ts": $fillFinishTs,
                 "status": ${status?.let { "\"$it\"" }},
-                "error_message": ${errorMessage?.let { "\"$it\"" }},
                 "ext": ${ext?.let { "\"$it\"" }}
             }
     """.trimIndent()
@@ -69,7 +68,7 @@ internal fun Ad.getImpressionInfo(): String {
     val networkName = networkName
     val placementId = null
     val placementName = null
-    val revenue = ecpm
+    val revenue = price
     val currency = currencyCode?.let { "\"$it\"" }
     val precision = if (adUnit.bidType == BidType.RTB) "exact" else "estimated"
     val demandSource = dsp?.let { "\"$it\"" }

--- a/bidon/src/main/java/org/bidon/sdk/ads/Ad.kt
+++ b/bidon/src/main/java/org/bidon/sdk/ads/Ad.kt
@@ -9,7 +9,7 @@ import org.bidon.sdk.stats.models.BidType
  */
 class Ad(
     val demandAd: DemandAd,
-    val ecpm: Double,
+    val price: Double,
     val auctionId: String,
     val dsp: String?,
     val currencyCode: String?,
@@ -23,6 +23,6 @@ class Ad(
         get() = adUnit.bidType
 
     override fun toString(): String {
-        return "Ad(${demandAd.adType} $networkName/$bidType $ecpm $currencyCode, auctionId=$auctionId, dsp=$dsp, extras=${demandAd.getExtras()}, $adUnit)"
+        return "Ad(${demandAd.adType} $networkName/$bidType $price $currencyCode, auctionId=$auctionId, dsp=$dsp, extras=${demandAd.getExtras()}, $adUnit)"
     }
 }

--- a/bidon/src/main/java/org/bidon/sdk/ads/AuctionInfo.kt
+++ b/bidon/src/main/java/org/bidon/sdk/ads/AuctionInfo.kt
@@ -18,8 +18,6 @@ class AdUnitInfo(
     val bidType: String?,
     val fillStartTs: Long?,
     val fillFinishTs: Long?,
-    val timeout: Long?,
     val status: String?,
-    val errorMessage: String? = null,
     val ext: String?,
 )

--- a/bidon/src/main/java/org/bidon/sdk/ads/banner/BannerManager.kt
+++ b/bidon/src/main/java/org/bidon/sdk/ads/banner/BannerManager.kt
@@ -281,9 +281,9 @@ class BannerManager private constructor(
         return extras.getExtras()
     }
 
-    override fun notifyLoss(activity: Activity, winnerDemandId: String, winnerEcpm: Double) {
+    override fun notifyLoss(activity: Activity, winnerDemandId: String, winnerPrice: Double) {
         activity.runOnUiThread {
-            nextBannerView?.notifyLoss(winnerDemandId, winnerEcpm)
+            nextBannerView?.notifyLoss(winnerDemandId, winnerPrice)
             nextBannerView = null
             nextAd = null
         }

--- a/bidon/src/main/java/org/bidon/sdk/ads/banner/BannerView.kt
+++ b/bidon/src/main/java/org/bidon/sdk/ads/banner/BannerView.kt
@@ -198,8 +198,8 @@ class BannerView @JvmOverloads constructor(
         userListener = listener
     }
 
-    override fun notifyLoss(winnerDemandId: String, winnerEcpm: Double) {
-        logInfo(TAG, "Notify Loss invoked with Winner($winnerDemandId, $winnerEcpm)")
+    override fun notifyLoss(winnerDemandId: String, winnerPrice: Double) {
+        logInfo(TAG, "Notify Loss invoked with Winner($winnerDemandId, $winnerPrice)")
         if (!BidonSdk.isInitialized()) {
             logInfo(TAG, "Sdk is not initialized")
             return
@@ -214,7 +214,7 @@ class BannerView @JvmOverloads constructor(
                 if (!wasNotified.getAndSet(true)) {
                     winner?.adSource?.sendLoss(
                         winnerDemandId = winnerDemandId,
-                        winnerEcpm = winnerEcpm,
+                        winnerPrice = winnerPrice,
                     )
                     destroyAd()
                 }

--- a/bidon/src/main/java/org/bidon/sdk/ads/banner/PositionedBanner.kt
+++ b/bidon/src/main/java/org/bidon/sdk/ads/banner/PositionedBanner.kt
@@ -57,6 +57,6 @@ interface PositionedBanner {
     fun destroyAd(activity: Activity)
     fun setBannerListener(listener: BannerListener?)
 
-    fun notifyLoss(activity: Activity, winnerDemandId: String, winnerEcpm: Double)
+    fun notifyLoss(activity: Activity, winnerDemandId: String, winnerPrice: Double)
     fun notifyWin()
 }

--- a/bidon/src/main/java/org/bidon/sdk/ads/banner/refresh/BannersCache.kt
+++ b/bidon/src/main/java/org/bidon/sdk/ads/banner/refresh/BannersCache.kt
@@ -39,7 +39,7 @@ internal class BannersCacheImpl : BannersCache {
     private val Tag get() = TAG
     private val isLoading = AtomicBoolean(false)
     private val cache = sortedMapOf<Pair<Ad, AuctionInfo>, BannerView>({ ad1, ad2 ->
-        ((ad2.first.ecpm - ad1.first.ecpm) * 1000000).toInt()
+        ((ad2.first.price - ad1.first.price) * 1000000).toInt()
     })
 
     override fun get(

--- a/bidon/src/main/java/org/bidon/sdk/ads/cache/impl/AdCacheImpl.kt
+++ b/bidon/src/main/java/org/bidon/sdk/ads/cache/impl/AdCacheImpl.kt
@@ -92,7 +92,7 @@ internal class AdCacheImpl(
             auction?.start(
                 demandAd = demandAd,
                 adTypeParam = adTypeParam.copy(
-                    pricefloor = maxOf(adTypeParam.pricefloor, results.value.firstOrNull()?.adSource?.getStats()?.ecpm ?: 0.0)
+                    pricefloor = maxOf(adTypeParam.pricefloor, results.value.firstOrNull()?.adSource?.getStats()?.price ?: 0.0)
                 ),
                 onSuccess = { winners, auctionInfo ->
                     scope.launch {
@@ -150,7 +150,7 @@ internal class AdCacheImpl(
 
     private fun List<AuctionResult>.asString(): String {
         return "(${this.size}) " + this.joinToString { auctionResult ->
-            auctionResult.adSource.getStats().let { "${it.demandId.demandId}:${it.ecpm}" }
+            auctionResult.adSource.getStats().let { "${it.demandId.demandId}:${it.price}" }
         }
     }
 }

--- a/bidon/src/main/java/org/bidon/sdk/ads/ext/AuctionInfoExt.kt
+++ b/bidon/src/main/java/org/bidon/sdk/ads/ext/AuctionInfoExt.kt
@@ -16,8 +16,6 @@ internal fun StatsAdUnit.toAuctionInfo() =
         fillStartTs = fillStartTs,
         fillFinishTs = fillFinishTs,
         status = status,
-        errorMessage = errorMessage,
-        timeout = timeout,
         ext = ext.toString(),
     )
 
@@ -31,7 +29,5 @@ internal fun AdUnit.toAuctionNoBidInfo() =
         fillStartTs = null,
         fillFinishTs = null,
         status = RoundStatus.NoBid.code,
-        timeout = timeout,
-        errorMessage = null,
         ext = extra.toString(),
     )

--- a/bidon/src/main/java/org/bidon/sdk/ads/interstitial/InterstitialImpl.kt
+++ b/bidon/src/main/java/org/bidon/sdk/ads/interstitial/InterstitialImpl.kt
@@ -108,12 +108,12 @@ internal class InterstitialImpl(
         this.userListener = listener
     }
 
-    override fun notifyLoss(winnerDemandId: String, winnerEcpm: Double) {
+    override fun notifyLoss(winnerDemandId: String, winnerPrice: Double) {
         if (!BidonSdk.isInitialized()) {
             logInfo(TAG, "Sdk is not initialized")
             return
         }
-        adCache.pop()?.adSource?.sendLoss(winnerDemandId, winnerEcpm)
+        adCache.pop()?.adSource?.sendLoss(winnerDemandId, winnerPrice)
         destroyAd()
     }
 

--- a/bidon/src/main/java/org/bidon/sdk/ads/rewarded/RewardedImpl.kt
+++ b/bidon/src/main/java/org/bidon/sdk/ads/rewarded/RewardedImpl.kt
@@ -103,12 +103,12 @@ internal class RewardedImpl(
         this.userListener = listener
     }
 
-    override fun notifyLoss(winnerDemandId: String, winnerEcpm: Double) {
+    override fun notifyLoss(winnerDemandId: String, winnerPrice: Double) {
         if (!BidonSdk.isInitialized()) {
             logInfo(TAG, "Sdk is not initialized")
             return
         }
-        adCache.pop()?.adSource?.sendLoss(winnerDemandId, winnerEcpm)
+        adCache.pop()?.adSource?.sendLoss(winnerDemandId, winnerPrice)
         destroyAd()
     }
 

--- a/bidon/src/main/java/org/bidon/sdk/auction/ExternalWinLossNotification.kt
+++ b/bidon/src/main/java/org/bidon/sdk/auction/ExternalWinLossNotification.kt
@@ -8,7 +8,7 @@ internal interface ExternalWinLossNotification {
 
     fun notifyLoss(
         winnerDemandId: String,
-        winnerEcpm: Double,
+        winnerPrice: Double,
 
         /**
          * The publisher should be informed about failed loading in case of auction is cancelled.

--- a/bidon/src/main/java/org/bidon/sdk/auction/impl/AuctionImpl.kt
+++ b/bidon/src/main/java/org/bidon/sdk/auction/impl/AuctionImpl.kt
@@ -286,7 +286,7 @@ internal class AuctionImpl(
                     logInfo(TAG, "Notified loss: ${adSource.demandId}")
                     adSource.notifyLoss(
                         winner.adSource.demandId.demandId,
-                        winner.adSource.getStats().ecpm
+                        winner.adSource.getStats().price
                     )
                 }
                 if (auctionResult.roundStatus == RoundStatus.Successful) {

--- a/bidon/src/main/java/org/bidon/sdk/auction/impl/PriceAuctionResolver.kt
+++ b/bidon/src/main/java/org/bidon/sdk/auction/impl/PriceAuctionResolver.kt
@@ -6,7 +6,7 @@ import org.bidon.sdk.auction.models.AuctionResult
 /**
  * Created by Bidon Team on 06/02/2023.
  */
-internal val MaxEcpmAuctionResolver: AuctionResolver by lazy {
+internal val MaxPriceAuctionResolver: AuctionResolver by lazy {
     PriceAuctionResolver()
 }
 
@@ -14,8 +14,8 @@ private class PriceAuctionResolver : AuctionResolver {
     override suspend fun sortWinners(list: List<AuctionResult>): List<AuctionResult> {
         return list.sortedByDescending {
             when (it) {
-                is AuctionResult.Bidding -> it.adSource.getStats().ecpm
-                is AuctionResult.Network -> it.adSource.getStats().ecpm
+                is AuctionResult.Bidding -> it.adSource.getStats().price
+                is AuctionResult.Network -> it.adSource.getStats().price
                 is AuctionResult.AuctionFailed -> it.adUnit.pricefloor
             }
         }

--- a/bidon/src/main/java/org/bidon/sdk/auction/impl/ResultsCollectorImpl.kt
+++ b/bidon/src/main/java/org/bidon/sdk/auction/impl/ResultsCollectorImpl.kt
@@ -164,9 +164,9 @@ internal class ResultsCollectorImpl(
             .filter { it.roundStatus == RoundStatus.Successful }
             .filter {
                 /**
-                 * Received ecpm should not be less then initial one [sourcePriceFloor].
+                 * Received price should not be less then initial one [sourcePriceFloor].
                  */
-                val isAbovePricefloor = it.adSource.getStats().ecpm >= sourcePriceFloor
+                val isAbovePricefloor = it.adSource.getStats().price >= sourcePriceFloor
                 if (!isAbovePricefloor) {
                     it.adSource.markBelowPricefloor()
                 }
@@ -187,7 +187,7 @@ internal class ResultsCollectorImpl(
                                 logInfo(TAG, "Notified loss: ${adSource.demandId}")
                                 adSource.notifyLoss(
                                     winner.adSource.demandId.demandId,
-                                    winner.adSource.getStats().ecpm
+                                    winner.adSource.getStats().price
                                 )
                             }
                             if (auctionResult.roundStatus == RoundStatus.Successful) {

--- a/bidon/src/main/java/org/bidon/sdk/auction/models/AuctionResult.kt
+++ b/bidon/src/main/java/org/bidon/sdk/auction/models/AuctionResult.kt
@@ -16,7 +16,7 @@ sealed interface AuctionResult {
         override val roundStatus: RoundStatus,
     ) : AuctionResult {
         override fun toString(): String {
-            return "AuctionResult.Network(ecpm=${adSource.getStats().ecpm}, roundStatus=$roundStatus, ${adSource.demandId})"
+            return "AuctionResult.Network(price=${adSource.getStats().price}, roundStatus=$roundStatus, ${adSource.demandId})"
         }
     }
 
@@ -25,7 +25,7 @@ sealed interface AuctionResult {
         override val roundStatus: RoundStatus,
     ) : AuctionResult {
         override fun toString(): String {
-            return "AuctionResult.Bidding(ecpm=${adSource.getStats().ecpm}, roundStatus=$roundStatus, ${adSource.demandId})"
+            return "AuctionResult.Bidding(price=${adSource.getStats().price}, roundStatus=$roundStatus, ${adSource.demandId})"
         }
     }
 
@@ -36,7 +36,7 @@ sealed interface AuctionResult {
     ) : AuctionResult {
         override val adSource: AdSource<*> get() = error("unexpected")
         override fun toString(): String {
-            return "AuctionResult.${adUnit.getType()}(ecpm=${adUnit.pricefloor}, roundStatus=$roundStatus, ${adUnit.demandId})"
+            return "AuctionResult.${adUnit.getType()}(price=${adUnit.pricefloor}, roundStatus=$roundStatus, ${adUnit.demandId})"
         }
     }
 }

--- a/bidon/src/main/java/org/bidon/sdk/auction/usecases/impl/AuctionStatImpl.kt
+++ b/bidon/src/main/java/org/bidon/sdk/auction/usecases/impl/AuctionStatImpl.kt
@@ -115,7 +115,7 @@ internal class AuctionStatImpl(
             auctionId = auctionId,
             pricefloor = result.pricefloor,
             winnerDemandId = roundWinner?.adSource?.demandId,
-            winnerEcpm = roundWinner?.adSource?.getStats()?.ecpm,
+            winnerPrice = roundWinner?.adSource?.getStats()?.price,
             noBids = result.noBidsInfo,
             demands = results,
         )
@@ -128,7 +128,7 @@ internal class AuctionStatImpl(
                 StatsAdUnit(
                     demandId = stat.demandId.demandId,
                     status = roundStatus.code,
-                    price = stat.ecpm,
+                    price = stat.price,
                     tokenStartTs = null,
                     tokenFinishTs = null,
                     bidType = BidType.CPM.code,
@@ -147,7 +147,7 @@ internal class AuctionStatImpl(
                 StatsAdUnit(
                     demandId = stat.demandId.demandId,
                     status = roundStatus.code,
-                    price = stat.ecpm,
+                    price = stat.price,
                     tokenStartTs = stat.tokenInfo?.tokenStartTs,
                     tokenFinishTs = stat.tokenInfo?.tokenFinishTs,
                     bidType = BidType.RTB.code,
@@ -190,7 +190,7 @@ internal class AuctionStatImpl(
                 auctionId = auctionId,
                 pricefloor = auctionData.pricefloor,
                 winnerDemandId = winner?.adSource?.demandId,
-                winnerEcpm = winner?.adSource?.getStats()?.ecpm,
+                winnerPrice = winner?.adSource?.getStats()?.price,
                 demands = roundStat.demands.map { demandStat ->
                     demandStat.copy(
                         status = getFinalStatus(
@@ -198,7 +198,7 @@ internal class AuctionStatImpl(
 
                             isWinner = demandStat.demandId == (winner as? AuctionResult.Network)?.adSource?.demandId?.demandId &&
                                 demandStat.adUnitUid == (winner as? AuctionResult.Network)?.adSource?.getStats()?.adUnit?.uid &&
-                                demandStat.price == (winner as? AuctionResult.Network)?.adSource?.getStats()?.ecpm
+                                demandStat.price == (winner as? AuctionResult.Network)?.adSource?.getStats()?.price
                         )
                     )
                 },
@@ -232,8 +232,8 @@ internal class AuctionStatImpl(
 
     private fun updateWinnerIfNeed(roundWinner: AuctionResult?): AuctionResult? {
         if (roundWinner == null) return winner
-        val currentEcpm = winner?.adSource?.getStats()?.ecpm ?: 0.0
-        return if (currentEcpm < roundWinner.adSource.getStats().ecpm) {
+        val currentPrice = winner?.adSource?.getStats()?.price ?: 0.0
+        return if (currentPrice < roundWinner.adSource.getStats().price) {
             this.winner = roundWinner
             roundWinner
         } else {
@@ -272,7 +272,7 @@ internal class AuctionStatImpl(
                 else -> "FAIL"
             },
             winnerDemandId = stat?.demandId?.demandId.takeIf { isSucceed },
-            price = stat?.ecpm.takeIf { isSucceed },
+            price = stat?.price.takeIf { isSucceed },
             auctionStartTs = auctionStartTs,
             auctionFinishTs = auctionFinishTs,
             bidType = stat?.bidType?.code,

--- a/bidon/src/main/java/org/bidon/sdk/auction/usecases/impl/ExecuteAuctionUseCaseImpl.kt
+++ b/bidon/src/main/java/org/bidon/sdk/auction/usecases/impl/ExecuteAuctionUseCaseImpl.kt
@@ -124,7 +124,7 @@ internal class ExecuteAuctionUseCaseImpl(
                         if (auctionResult.roundStatus == RoundStatus.Successful &&
                             !shouldRequestNext(auctionResult = auctionResult, next = nextRequested)
                         ) {
-                            logInfo(TAG, "Request was skipped since the filled eCPM larger than the next one")
+                            logInfo(TAG, "Request was skipped since the filled price larger than the next one")
                             adUnitQueue.forEach {
                                 resultsCollector.add(
                                     getBelowPriceFloorResult(
@@ -215,10 +215,10 @@ internal class ExecuteAuctionUseCaseImpl(
         if (next == null) {
             return false
         }
-        val currentEcpm = auctionResult.adSource.getStats().ecpm
-        val nextEcpm = next.pricefloor
-        logInfo(TAG, "Loaded eCPM: $currentEcpm, next requested eCPM: $nextEcpm")
-        return currentEcpm < nextEcpm
+        val currentPrice = auctionResult.adSource.getStats().price
+        val nextPrice = next.pricefloor
+        logInfo(TAG, "Loaded price: $currentPrice, next requested price: $nextPrice")
+        return currentPrice < nextPrice
     }
 
     private fun applyParams(

--- a/bidon/src/main/java/org/bidon/sdk/auction/usecases/impl/RequestAdUnitUseCaseImpl.kt
+++ b/bidon/src/main/java/org/bidon/sdk/auction/usecases/impl/RequestAdUnitUseCaseImpl.kt
@@ -72,7 +72,7 @@ internal class RequestAdUnitUseCaseImpl : RequestAdUnitUseCase {
 
             logInfo(TAG, "FillFinished: $adUnit. \nResult: ${auctionResult.roundStatus}")
 
-            adSource.markFillFinished(requestStatus, adSource.ad?.ecpm)
+            adSource.markFillFinished(requestStatus, adSource.ad?.price)
 
             auctionResult
         }

--- a/bidon/src/main/java/org/bidon/sdk/regulation/Iab.kt
+++ b/bidon/src/main/java/org/bidon/sdk/regulation/Iab.kt
@@ -3,7 +3,7 @@ package org.bidon.sdk.regulation
 /**
  * [Consent Management Provider](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/CMP%20JS%20API%20v1.1%20Final.md)
  */
-data class Iab(
+internal data class Iab(
     val tcfV1: String?,
     val tcfV2: String?,
     val usPrivacy: String?,

--- a/bidon/src/main/java/org/bidon/sdk/regulation/Regulation.kt
+++ b/bidon/src/main/java/org/bidon/sdk/regulation/Regulation.kt
@@ -24,6 +24,4 @@ interface Regulation {
      */
     var coppa: Coppa
     val coppaApplies: Boolean get() = coppa == Coppa.Yes
-
-    val iab: Iab
 }

--- a/bidon/src/main/java/org/bidon/sdk/regulation/impl/RegulationImpl.kt
+++ b/bidon/src/main/java/org/bidon/sdk/regulation/impl/RegulationImpl.kt
@@ -2,13 +2,9 @@ package org.bidon.sdk.regulation.impl
 
 import org.bidon.sdk.regulation.Coppa
 import org.bidon.sdk.regulation.Gdpr
-import org.bidon.sdk.regulation.Iab
-import org.bidon.sdk.regulation.IabConsent
 import org.bidon.sdk.regulation.Regulation
 
-internal class RegulationImpl(
-    private val iabConsent: IabConsent
-) : Regulation {
+internal class RegulationImpl : Regulation {
     override var coppa: Coppa = Coppa.Default
 
     override var gdpr: Gdpr = Gdpr.Default
@@ -31,7 +27,4 @@ internal class RegulationImpl(
              */
             return usPrivacyString[0] == '1' && usPrivacyString[2].uppercaseChar() == 'N'
         }
-
-    override val iab: Iab
-        get() = iabConsent.iab
 }

--- a/bidon/src/main/java/org/bidon/sdk/segment/Segment.kt
+++ b/bidon/src/main/java/org/bidon/sdk/segment/Segment.kt
@@ -40,4 +40,9 @@ interface Segment {
      * If value is null, then the existing attribute will be removed.
      */
     fun putCustomAttribute(attribute: String, value: Any?)
+
+    /**
+     * Retrieves all custom attributes.
+     */
+    fun getCustomAttributes(): Map<String, Any>
 }

--- a/bidon/src/main/java/org/bidon/sdk/segment/impl/SegmentImpl.kt
+++ b/bidon/src/main/java/org/bidon/sdk/segment/impl/SegmentImpl.kt
@@ -96,6 +96,10 @@ internal class SegmentImpl : Segment, SegmentSynchronizer {
         logInfo(TAG, "Updated attributes=$attributes")
     }
 
+    override fun getCustomAttributes(): Map<String, Any> {
+        return attributesFlow.value.customAttributes
+    }
+
     override fun parseSegmentUid(rootJsonResponse: String) {
         runCatching {
             val newSegmentUid = JSONObject(rootJsonResponse)

--- a/bidon/src/main/java/org/bidon/sdk/stats/StatisticsCollector.kt
+++ b/bidon/src/main/java/org/bidon/sdk/stats/StatisticsCollector.kt
@@ -23,7 +23,7 @@ interface StatisticsCollector {
     fun sendShowImpression()
     fun sendClickImpression()
     fun sendRewardImpression()
-    fun sendLoss(winnerDemandId: String, winnerEcpm: Double)
+    fun sendLoss(winnerDemandId: String, winnerPrice: Double)
     fun sendWin()
 
     /**
@@ -39,7 +39,7 @@ interface StatisticsCollector {
     fun setDsp(dspSource: String?)
     fun setTokenInfo(tokenInfo: TokenInfo)
     fun markFillStarted(adUnit: AdUnit, pricefloor: Double?)
-    fun markFillFinished(roundStatus: RoundStatus, ecpm: Double?)
+    fun markFillFinished(roundStatus: RoundStatus, price: Double?)
     fun markWin()
     fun markLoss()
     fun markBelowPricefloor()

--- a/bidon/src/main/java/org/bidon/sdk/stats/WinLossNotifier.kt
+++ b/bidon/src/main/java/org/bidon/sdk/stats/WinLossNotifier.kt
@@ -1,6 +1,6 @@
 package org.bidon.sdk.stats
 
 interface WinLossNotifier {
-    fun notifyLoss(winnerDemandId: String, winnerEcpm: Double)
+    fun notifyLoss(winnerDemandId: String, winnerPrice: Double)
     fun notifyWin()
 }

--- a/bidon/src/main/java/org/bidon/sdk/stats/impl/SendWinLossRequestUseCaseImpl.kt
+++ b/bidon/src/main/java/org/bidon/sdk/stats/impl/SendWinLossRequestUseCaseImpl.kt
@@ -47,7 +47,7 @@ internal class SendWinLossRequestUseCaseImpl(
                     is WinLossRequestData.Loss -> {
                         Loss(
                             demandId = data.winnerDemandId,
-                            ecpm = data.winnerEcpm
+                            price = data.winnerPrice
                         )
                     }
 

--- a/bidon/src/main/java/org/bidon/sdk/stats/impl/StatisticsCollectorImpl.kt
+++ b/bidon/src/main/java/org/bidon/sdk/stats/impl/StatisticsCollectorImpl.kt
@@ -60,7 +60,7 @@ class StatisticsCollectorImpl : StatisticsCollector {
         fillStartTs = null,
         fillFinishTs = null,
         roundStatus = null,
-        ecpm = 0.0,
+        price = 0.0,
         dspSource = null,
         auctionPricefloor = 0.0,
         tokenInfo = null,
@@ -83,7 +83,7 @@ class StatisticsCollectorImpl : StatisticsCollector {
         }
         return Ad(
             demandAd = demandAd,
-            ecpm = stat.ecpm,
+            price = stat.price,
             currencyCode = AdValue.USD,
             auctionId = auctionId,
             dsp = stat.dspSource,
@@ -154,7 +154,7 @@ class StatisticsCollectorImpl : StatisticsCollector {
         }
     }
 
-    override fun sendLoss(winnerDemandId: String, winnerEcpm: Double) {
+    override fun sendLoss(winnerDemandId: String, winnerPrice: Double) {
         if (!externalWinNotificationsEnabled) {
             logInfo(TAG, "External WinLoss Notifications disabled: external_win_notifications=false")
             return
@@ -164,7 +164,7 @@ class StatisticsCollectorImpl : StatisticsCollector {
                 sendLossRequest.invoke(
                     WinLossRequestData.Loss(
                         winnerDemandId = winnerDemandId,
-                        winnerEcpm = winnerEcpm,
+                        winnerPrice = winnerPrice,
                         demandAd = demandAd,
                         body = createImpressionRequestBody(adType)
                     )
@@ -210,21 +210,21 @@ class StatisticsCollectorImpl : StatisticsCollector {
         stat = stat.copy(
             fillStartTs = SystemTimeNow,
             adUnit = adUnit,
-            ecpm = pricefloor ?: stat.ecpm,
+            price = pricefloor ?: stat.price,
         )
     }
 
-    override fun markFillFinished(roundStatus: RoundStatus, ecpm: Double?) {
+    override fun markFillFinished(roundStatus: RoundStatus, price: Double?) {
         stat = stat.copy(
             fillFinishTs = SystemTimeNow,
             roundStatus = roundStatus,
-            ecpm = ecpm ?: 0.0
+            price = price ?: 0.0
         )
     }
 
     override fun setPrice(price: Double) {
         stat = stat.copy(
-            ecpm = price
+            price = price
         )
     }
 
@@ -268,7 +268,7 @@ class StatisticsCollectorImpl : StatisticsCollector {
             auctionConfigurationId = auctionConfigurationId,
             auctionConfigurationUid = auctionConfigurationUid,
             demandId = demandId.demandId,
-            price = stat.ecpm,
+            price = stat.price,
             banner = banner,
             interstitial = interstitial,
             rewarded = rewarded,

--- a/bidon/src/main/java/org/bidon/sdk/stats/models/BidStat.kt
+++ b/bidon/src/main/java/org/bidon/sdk/stats/models/BidStat.kt
@@ -12,7 +12,7 @@ data class BidStat(
     val auctionId: String?,
     val demandId: DemandId,
     val roundStatus: RoundStatus?,
-    val ecpm: Double,
+    val price: Double,
     val auctionPricefloor: Double,
     val fillStartTs: Long?,
     val fillFinishTs: Long?,

--- a/bidon/src/main/java/org/bidon/sdk/stats/models/Loss.kt
+++ b/bidon/src/main/java/org/bidon/sdk/stats/models/Loss.kt
@@ -10,5 +10,5 @@ internal data class Loss(
     @field:JsonName("demand_id")
     val demandId: String,
     @field:JsonName("price")
-    val ecpm: Double,
+    val price: Double,
 ) : Serializable

--- a/bidon/src/main/java/org/bidon/sdk/stats/models/RoundStat.kt
+++ b/bidon/src/main/java/org/bidon/sdk/stats/models/RoundStat.kt
@@ -12,5 +12,5 @@ internal data class RoundStat(
     val demands: List<StatsAdUnit>,
     val noBids: List<AdUnit>?,
     val winnerDemandId: DemandId?,
-    val winnerEcpm: Double?,
+    val winnerPrice: Double?,
 )

--- a/bidon/src/main/java/org/bidon/sdk/stats/usecases/SendWinLossRequestUseCase.kt
+++ b/bidon/src/main/java/org/bidon/sdk/stats/usecases/SendWinLossRequestUseCase.kt
@@ -20,7 +20,7 @@ internal sealed interface WinLossRequestData {
 
     data class Loss(
         val winnerDemandId: String,
-        val winnerEcpm: Double,
+        val winnerPrice: Double,
         override val demandAd: DemandAd,
         override val body: ImpressionRequestBody
     ) : WinLossRequestData {

--- a/bidon/src/main/java/org/bidon/sdk/utils/di/DI.kt
+++ b/bidon/src/main/java/org/bidon/sdk/utils/di/DI.kt
@@ -23,7 +23,7 @@ import org.bidon.sdk.auction.Auction
 import org.bidon.sdk.auction.AuctionResolver
 import org.bidon.sdk.auction.ResultsCollector
 import org.bidon.sdk.auction.impl.AuctionImpl
-import org.bidon.sdk.auction.impl.MaxEcpmAuctionResolver
+import org.bidon.sdk.auction.impl.MaxPriceAuctionResolver
 import org.bidon.sdk.auction.impl.ResultsCollectorImpl
 import org.bidon.sdk.auction.usecases.AuctionStat
 import org.bidon.sdk.auction.usecases.ExecuteAuctionUseCase
@@ -178,7 +178,7 @@ internal object DI {
                 )
             }
             factory<AdapterInstanceCreator> { AdapterInstanceCreatorImpl() }
-            factory<AuctionResolver> { MaxEcpmAuctionResolver }
+            factory<AuctionResolver> { MaxPriceAuctionResolver }
             factory<Auction> {
                 AuctionImpl(
                     adaptersSource = get(),

--- a/bidon/src/main/java/org/bidon/sdk/utils/di/DI.kt
+++ b/bidon/src/main/java/org/bidon/sdk/utils/di/DI.kt
@@ -153,11 +153,7 @@ internal object DI {
 
             // [SegmentDataSource] should be singleton per session
             singleton<TokenDataSource> { TokenDataSourceImpl(keyValueStorage = get()) }
-            singleton<Regulation> {
-                RegulationImpl(
-                    iabConsent = get()
-                )
-            }
+            singleton<Regulation> { RegulationImpl() }
             /**
              * [SegmentSynchronizer] depends on it
              */
@@ -247,7 +243,10 @@ internal object DI {
             }
             factory<DataProvider> {
                 DataProviderImpl(
-                    deviceBinder = DeviceBinder(deviceDataSource = get(), locationDataSource = get()),
+                    deviceBinder = DeviceBinder(
+                        deviceDataSource = get(),
+                        locationDataSource = get()
+                    ),
                     appBinder = AppBinder(dataSource = get()),
                     sessionBinder = SessionBinder(dataSource = get()),
                     tokenBinder = TokenBinder(dataSource = get()),

--- a/bidon/src/test/java/org/bidon/sdk/auction/impl/ExecuteAuctionUseCaseImplTest.kt
+++ b/bidon/src/test/java/org/bidon/sdk/auction/impl/ExecuteAuctionUseCaseImplTest.kt
@@ -145,7 +145,7 @@ internal class ExecuteAuctionUseCaseImplTest : ConcurrentTest() {
 //                                roundId = "r123",
 //                                currencyCode = USD,
 //                                dsp = null,
-//                                ecpm = 1.3,
+//                                price = 1.3,
 //                                auctionId = "a123",
 //                                adUnit = AdUnit(
 //                                    demandId = "admob",

--- a/bidon/src/test/java/org/bidon/sdk/auction/usecases/AuctionStatImplTest.kt
+++ b/bidon/src/test/java/org/bidon/sdk/auction/usecases/AuctionStatImplTest.kt
@@ -13,7 +13,7 @@ import org.bidon.sdk.ads.AdType
 import org.bidon.sdk.ads.BidsInfo
 import org.bidon.sdk.ads.banner.helper.DeviceInfo
 import org.bidon.sdk.auction.AdTypeParam
-import org.bidon.sdk.auction.impl.MaxEcpmAuctionResolver
+import org.bidon.sdk.auction.impl.MaxPriceAuctionResolver
 import org.bidon.sdk.auction.models.AdUnit
 import org.bidon.sdk.auction.models.AuctionResponse
 import org.bidon.sdk.auction.models.AuctionResult
@@ -46,7 +46,7 @@ internal class AuctionStatImplTest : ConcurrentTest() {
     private val testee: AuctionStat by lazy {
         AuctionStatImpl(
             statsRequest = statRequestUseCase,
-            resolver = MaxEcpmAuctionResolver
+            resolver = MaxPriceAuctionResolver
         )
     }
 
@@ -100,7 +100,7 @@ internal class AuctionStatImplTest : ConcurrentTest() {
                                 every { it.demandId } returns DemandId("vungle")
                                 every { it.getStats() } returns BidStat(
                                     demandId = DemandId("vungle"),
-                                    ecpm = 1.24,
+                                    price = 1.24,
                                     auctionId = "auction_id_123",
                                     fillStartTs = 916,
                                     fillFinishTs = 917,
@@ -138,7 +138,7 @@ internal class AuctionStatImplTest : ConcurrentTest() {
                         adSource = mockk<AdSource<*>>(relaxed = true).also {
                             every { it.getStats() } returns BidStat(
                                 demandId = DemandId("bidmachine"),
-                                ecpm = 0.20,
+                                price = 0.20,
                                 auctionId = "auction_id_123",
                                 fillStartTs = 986,
                                 fillFinishTs = 987,
@@ -169,7 +169,7 @@ internal class AuctionStatImplTest : ConcurrentTest() {
                         adSource = mockk<AdSource<*>>(relaxed = true).also {
                             every { it.getStats() } returns BidStat(
                                 demandId = DemandId("admob"),
-                                ecpm = 26.0,
+                                price = 26.0,
                                 auctionId = "auction_id_123",
                                 fillStartTs = 986,
                                 fillFinishTs = 987,
@@ -267,7 +267,7 @@ internal class AuctionStatImplTest : ConcurrentTest() {
                 getDemandStatAdapter(demandId = "dem4", status = RoundStatus.UnknownAdapter),
                 getDemandStatAdapter(demandId = "bid3", status = RoundStatus.UnknownAdapter),
             ),
-            winnerEcpm = 1.24,
+            winnerPrice = 1.24,
             noBids = listOf(
                 BidsInfo(
                     bidType = BidType.RTB.code,
@@ -327,7 +327,7 @@ internal class AuctionStatImplTest : ConcurrentTest() {
                                 every { it.demandId } returns DemandId("bidmachine")
                                 every { it.getStats() } returns BidStat(
                                     demandId = DemandId("bidmachine"),
-                                    ecpm = 1.5,
+                                    price = 1.5,
                                     auctionId = "auction_id_123",
                                     fillStartTs = 916,
                                     fillFinishTs = 917,
@@ -360,7 +360,7 @@ internal class AuctionStatImplTest : ConcurrentTest() {
                         adSource = mockk<AdSource<*>>(relaxed = true).also {
                             every { it.getStats() } returns BidStat(
                                 demandId = DemandId("dem1"),
-                                ecpm = 1.3,
+                                price = 1.3,
                                 auctionId = "auction_id_123",
                                 fillStartTs = 986,
                                 fillFinishTs = 987,
@@ -391,7 +391,7 @@ internal class AuctionStatImplTest : ConcurrentTest() {
                         adSource = mockk<AdSource<*>>(relaxed = true).also {
                             every { it.getStats() } returns BidStat(
                                 demandId = DemandId("dem2"),
-                                ecpm = 10.5,
+                                price = 10.5,
                                 auctionId = "auction_id_123",
                                 fillStartTs = 986,
                                 fillFinishTs = 987,
@@ -492,7 +492,7 @@ internal class AuctionStatImplTest : ConcurrentTest() {
                 getDemandStatAdapter(demandId = "dem3", status = RoundStatus.UnknownAdapter),
                 getDemandStatAdapter(demandId = "dem4", status = RoundStatus.UnknownAdapter),
             ),
-            winnerEcpm = 1.5,
+            winnerPrice = 1.5,
             winnerDemandId = DemandId("bidmachine"),
             noBids = listOf(
                 BidsInfo(
@@ -593,7 +593,7 @@ internal class AuctionStatImplTest : ConcurrentTest() {
                                 every { it.demandId } returns DemandId("bidmachine")
                                 every { it.getStats() } returns BidStat(
                                     demandId = DemandId("bidmachine"),
-                                    ecpm = 1.5,
+                                    price = 1.5,
                                     auctionId = "auction_id_123",
                                     fillStartTs = 916,
                                     fillFinishTs = 917,
@@ -626,7 +626,7 @@ internal class AuctionStatImplTest : ConcurrentTest() {
                         adSource = mockk<AdSource<*>>(relaxed = true).also {
                             every { it.getStats() } returns BidStat(
                                 demandId = DemandId("dem1"),
-                                ecpm = 1.3,
+                                price = 1.3,
                                 auctionId = "auction_id_123",
                                 fillStartTs = 986,
                                 fillFinishTs = 987,
@@ -657,7 +657,7 @@ internal class AuctionStatImplTest : ConcurrentTest() {
                         adSource = mockk<AdSource<*>>(relaxed = true).also {
                             every { it.getStats() } returns BidStat(
                                 demandId = DemandId("dem2"),
-                                ecpm = 10.5,
+                                price = 10.5,
                                 auctionId = "auction_id_123",
                                 fillStartTs = 986,
                                 fillFinishTs = 987,

--- a/bidon/src/test/java/org/bidon/sdk/config/models/adapters/TestBiddingInterstitialImpl.kt
+++ b/bidon/src/test/java/org/bidon/sdk/config/models/adapters/TestBiddingInterstitialImpl.kt
@@ -28,7 +28,7 @@ internal class TestBiddingInterstitialImpl(
 //    override val ad: Ad
 //        get() = Ad(
 //            demandAd = demandAd,
-//            ecpm = adParams.lineItem.pricefloor,
+//            price = adParams.lineItem.pricefloor,
 //            roundId = roundId,
 //            networkName = "monetizationNetwork-asd",
 //            dsp = "DSP-bidmachine",

--- a/bidon/src/test/java/org/bidon/sdk/config/models/adapters/TestInterstitialImpl.kt
+++ b/bidon/src/test/java/org/bidon/sdk/config/models/adapters/TestInterstitialImpl.kt
@@ -27,7 +27,7 @@ internal class TestInterstitialImpl(
 //    override val ad: Ad
 //        get() = Ad(
 //            demandAd = demandAd,
-//            ecpm = adParams.lineItem.pricefloor,
+//            price = adParams.lineItem.pricefloor,
 //            roundId = roundId,
 //            networkName = "monetizationNetwork-asd",
 //            dsp = "DSP-bidmachine",

--- a/bidon/src/test/java/org/bidon/sdk/config/models/auctions/impl/AuctionImplTest.kt
+++ b/bidon/src/test/java/org/bidon/sdk/config/models/auctions/impl/AuctionImplTest.kt
@@ -18,7 +18,7 @@ import org.bidon.sdk.ads.banner.helper.DeviceInfo
 import org.bidon.sdk.auction.AdTypeParam
 import org.bidon.sdk.auction.Auction
 import org.bidon.sdk.auction.impl.AuctionImpl
-import org.bidon.sdk.auction.impl.MaxEcpmAuctionResolver
+import org.bidon.sdk.auction.impl.MaxPriceAuctionResolver
 import org.bidon.sdk.auction.models.AdUnit
 import org.bidon.sdk.auction.models.AuctionResponse
 import org.bidon.sdk.auction.usecases.AuctionStat
@@ -65,7 +65,7 @@ internal class AuctionImplTest : ConcurrentTest() {
     private val auctionStat: AuctionStat by lazy {
         AuctionStatImpl(
             statRequestUseCase,
-            resolver = MaxEcpmAuctionResolver
+            resolver = MaxPriceAuctionResolver
         )
     }
 
@@ -194,8 +194,8 @@ internal class AuctionImplTest : ConcurrentTest() {
                 val winnerAd = winner.adSource.ad
                 requireNotNull(winnerAd)
                 assertThat(winnerAd.adUnit.label).isEqualTo("admob2")
-                assertThat(winnerAd.ecpm).isEqualTo(2.2235)
-                assertThat(winner.adSource.getStats().ecpm).isEqualTo(2.2235)
+                assertThat(winnerAd.price).isEqualTo(2.2235)
+                assertThat(winner.adSource.getStats().price).isEqualTo(2.2235)
                 val roundStat = slot<List<RoundStat>>()
                 val demandAd = slot<DemandAd>()
                 // AND CHECK STAT REQUEST
@@ -274,8 +274,8 @@ internal class AuctionImplTest : ConcurrentTest() {
                 val winnerAd = winner.adSource.ad
                 requireNotNull(winnerAd)
                 assertThat(winnerAd.adUnit.label).isEqualTo("AAAA2")
-                assertThat(winnerAd.ecpm).isEqualTo(2.25)
-                assertThat(winner.adSource.getStats().ecpm).isEqualTo(2.25)
+                assertThat(winnerAd.price).isEqualTo(2.25)
+                assertThat(winner.adSource.getStats().price).isEqualTo(2.25)
             },
             onFailure = { auctionInfo, throwable ->
                 error("unexpected: $throwable")


### PR DESCRIPTION
[BDN-840 [Android] Synchronize iOS/Android Public API for BidonSDK 0.7](https://appodeal.atlassian.net/browse/BDN-840)

[Android & iOS Bidon SDKs v0.7 API discrepancies](https://docs.google.com/spreadsheets/d/1OziCh6Fepic3UsT-PPtl3yC3Y0kr2ZOXrfPoX94Wq-0/edit?gid=0#gid=0)

### Changes:
- Segment.getCustomAttributes() method
- Rename Ad obj ecpm field to price field
- Remove AdUnitInfo obj timeout and errorMessage fields


This pull request includes several changes primarily focused on renaming variables and method parameters related to ad pricing and revenue from `ecpm` to `price`. This change is reflected across multiple files and classes to maintain consistency throughout the codebase.

### Variable and Method Parameter Renaming:

* [`adapter/appsflyer/src/main/java/org/bidon/appsflyer/AppsflyerAnalytics.kt`](diffhunk://#diff-19cb5621bec5649c0ea6bcadaf3d3c54792afad20f0c4d6194d5a3896df60fc6L66-R66): Changed `eventRevenue` from `ad.ecpm` to `ad.price`.
* [`adapter/fyber/src/main/java/org/bidon/fyber/FairBidAdapter.kt`](diffhunk://#diff-c616700e929c4d57e81b10f8a2ad1ba06bfa3f57a944cdf4fda97b150f6d043eL72-R72): Renamed `ecpm` to `price` in the `FairBidAdapter` class.
* [`app/src/main/java/org/bidon/demoapp/JavaMainActivity.java`](diffhunk://#diff-33b08a6456a21b12e25a3ea433784d5cc2b9cb9b4611a3f3ad35ba454a6c9b91L66-R66): Updated method parameter from `ad.getEcpm()` to `ad.getPrice()`.
* [`app/src/main/java/org/bidon/demoapp/ui/BannerScreen.kt`](diffhunk://#diff-b2e68906408990799df2d35841d497f2c07f3723d1aacb4e23d99db6e26f353bL212-R212): Changed `winnerEcpm` to `winnerPrice` in the `notifyLoss` method.
* [`bidon/src/main/java/org/bidon/sdk/ads/Ad.kt`](diffhunk://#diff-91fe5c26f7a385242d411adaf661ec29d7462e471d3e691ada48b7dad36c73b2L12-R12): Updated the `Ad` class to use `price` instead of `ecpm`. [[1]](diffhunk://#diff-91fe5c26f7a385242d411adaf661ec29d7462e471d3e691ada48b7dad36c73b2L12-R12) [[2]](diffhunk://#diff-91fe5c26f7a385242d411adaf661ec29d7462e471d3e691ada48b7dad36c73b2L26-R26)

### Consistency in Ad Revenue Handling:

* [`app/src/main/java/org/bidon/demoapp/ui/ext/Ext.kt`](diffhunk://#diff-5d2a95d3f919cbd2db095a789042a304be2d5d6ab349af6f36ff9e536b2a67b6L72-R71): Changed `revenue` from `ecpm` to `price` in the `getImpressionInfo` method.
* [`bidon/src/main/java/org/bidon/sdk/ads/banner/BannerManager.kt`](diffhunk://#diff-5bff639ea6e5502c8346d1f51904240d77dd3738bc4acc907f6097a9c79e4780L284-R286): Updated the `notifyLoss` method to use `winnerPrice` instead of `winnerEcpm`.
* [`bidon/src/main/java/org/bidon/sdk/ads/banner/BannerView.kt`](diffhunk://#diff-fd0edbf768fd3f37c49743586ef8fb6925a600be59e9cde14defeee379aadd72L201-R202): Renamed `winnerEcpm` to `winnerPrice` in the `notifyLoss` method. [[1]](diffhunk://#diff-fd0edbf768fd3f37c49743586ef8fb6925a600be59e9cde14defeee379aadd72L201-R202) [[2]](diffhunk://#diff-fd0edbf768fd3f37c49743586ef8fb6925a600be59e9cde14defeee379aadd72L217-R217)
* [`bidon/src/main/java/org/bidon/sdk/ads/cache/impl/AdCacheImpl.kt`](diffhunk://#diff-cb572e112b18a1c3e11fc6ae11dd6a0ba9a7ee005690dccf3b2abfc5abd7a172L95-R95): Updated `pricefloor` comparison to use `price` instead of `ecpm`. [[1]](diffhunk://#diff-cb572e112b18a1c3e11fc6ae11dd6a0ba9a7ee005690dccf3b2abfc5abd7a172L95-R95) [[2]](diffhunk://#diff-cb572e112b18a1c3e11fc6ae11dd6a0ba9a7ee005690dccf3b2abfc5abd7a172L153-R153)
* [`bidon/src/main/java/org/bidon/sdk/auction/impl/AuctionImpl.kt`](diffhunk://#diff-bfe205b9f227343dd30a37d23390c706cad4946f6049dc007065cca4f7706c2fL289-R289): Changed the notification of loss to use `price` instead of `ecpm`.

### Removal of Unused Fields:

* [`bidon/src/main/java/org/bidon/sdk/ads/AuctionInfo.kt`](diffhunk://#diff-0414364543d8a3433e3441ce8e7a09e55140f96338a96a8da6e3f553d7b54484L21-L23): Removed `timeout` and `errorMessage` fields from `AdUnitInfo` class.
* [`bidon/src/main/java/org/bidon/sdk/ads/ext/AuctionInfoExt.kt`](diffhunk://#diff-07156c1861840c47205247d49dcb40a8201d11af72157fe770a956e02c3638e4L19-L20): Removed `timeout` and `errorMessage` fields from `toAuctionInfo` and `toAuctionNoBidInfo` methods. [[1]](diffhunk://#diff-07156c1861840c47205247d49dcb40a8201d11af72157fe770a956e02c3638e4L19-L20) [[2]](diffhunk://#diff-07156c1861840c47205247d49dcb40a8201d11af72157fe770a956e02c3638e4L34-L35)

### Documentation and Miscellaneous:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R4): Added a new feature entry for synchronizing the public API for Unity plugin.