### PR TITLE
Feature/BDN-895: Implemented ability to obtain banner size in BannerManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# develop
+## Features:
+- [BDN-895](https://appodeal.atlassian.net/browse/BDN-895) Implemented ability to obtain banner size in BannerManager
+
 # 0.7.3
 ## Features:
 - [BDN-840](https://appodeal.atlassian.net/browse/BDN-840) Synchronize public api for Unity plugin

--- a/bidon/src/main/java/org/bidon/sdk/ads/banner/BannerManager.kt
+++ b/bidon/src/main/java/org/bidon/sdk/ads/banner/BannerManager.kt
@@ -54,7 +54,7 @@ class BannerManager private constructor(
     private var _bannerFormat: BannerFormat = BannerFormat.Banner
 
     override val bannerFormat: BannerFormat get() = _bannerFormat
-    override val adSize: AdSize? get() = currentBannerView?.adSize
+    override val adSize: AdSize? get() = nextBannerView?.adSize ?: currentBannerView?.adSize
 
     override var isDisplaying: Boolean = false
         private set


### PR DESCRIPTION
https://appodeal.atlassian.net/browse/BDN-895
This pull request includes changes to add a new feature for obtaining banner size in the `BannerManager` and an update to the `CHANGELOG.md` file to document this new feature.

### New Feature Implementation:

* [`bidon/src/main/java/org/bidon/sdk/ads/banner/BannerManager.kt`](diffhunk://#diff-5bff639ea6e5502c8346d1f51904240d77dd3738bc4acc907f6097a9c79e4780L57-R57): Modified the `adSize` property to prioritize `nextBannerView`'s size over `currentBannerView`'s size.

### Documentation Update:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R4): Added an entry for the new feature under the develop section, referencing the implementation of obtaining banner size in `BannerManager` (BDN-895).