### PR TITLE
Feature/BDN-946 Handled `custom_parameters` from server and provided to BidMachine SDK ad requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # develop (2025.*.*)
 ## Features:
 - [BDN-933](https://appodeal.atlassian.net/browse/BDN-933) Added BCA-MAX to Bidon Sdk repository and publish to Bidon artifactory
+- [BDN-946](https://appodeal.atlassian.net/browse/BDN-946) Handled `custom_parameters` from server and provided to BidMachine SDK ad requests
 
 # 0.7.8 (2025.05.07)
 ## Features:

--- a/adapter/bidmachine/src/main/java/org/bidon/bidmachine/BidMachineParameters.kt
+++ b/adapter/bidmachine/src/main/java/org/bidon/bidmachine/BidMachineParameters.kt
@@ -2,6 +2,7 @@ package org.bidon.bidmachine
 
 import android.app.Activity
 import android.content.Context
+import io.bidmachine.CustomParams
 import org.bidon.sdk.adapter.AdAuctionParams
 import org.bidon.sdk.adapter.AdapterParameters
 import org.bidon.sdk.ads.banner.BannerFormat
@@ -19,7 +20,8 @@ class BMBannerAuctionParams(
     val activity: Activity,
     val bannerFormat: BannerFormat,
     val timeout: Long,
-    val payload: String?
+    val customParameters: CustomParams,
+    val payload: String?,
 ) : AdAuctionParams {
 
     override fun toString(): String {
@@ -32,7 +34,8 @@ class BMFullscreenAuctionParams(
     override val adUnit: AdUnit,
     val context: Context,
     val timeout: Long,
-    val payload: String?
+    val customParameters: CustomParams,
+    val payload: String?,
 ) : AdAuctionParams {
 
     override fun toString(): String {

--- a/adapter/bidmachine/src/main/java/org/bidon/bidmachine/impl/BMBannerAdImpl.kt
+++ b/adapter/bidmachine/src/main/java/org/bidon/bidmachine/impl/BMBannerAdImpl.kt
@@ -1,7 +1,6 @@
 package org.bidon.bidmachine.impl
 
 import io.bidmachine.AdRequest
-import io.bidmachine.CustomParams
 import io.bidmachine.PriceFloorParams
 import io.bidmachine.banner.BannerListener
 import io.bidmachine.banner.BannerRequest
@@ -55,7 +54,7 @@ internal class BMBannerAdImpl(
                 }
                 .setSize(adParams.bannerFormat.asBidMachineBannerSize())
                 .setPriceFloorParams(PriceFloorParams().addPriceFloor(adParams.price))
-                .setCustomParams(CustomParams().addParam("mediation_mode", "bidon"))
+                .setCustomParams(adParams.customParameters)
                 .setLoadingTimeOut(adParams.timeout.toInt())
                 .setListener(
                     object : AdRequest.AdRequestListener<BannerRequest> {

--- a/adapter/bidmachine/src/main/java/org/bidon/bidmachine/impl/BMInterstitialAdImpl.kt
+++ b/adapter/bidmachine/src/main/java/org/bidon/bidmachine/impl/BMInterstitialAdImpl.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.content.Context
 import io.bidmachine.AdContentType
 import io.bidmachine.AdRequest
-import io.bidmachine.CustomParams
 import io.bidmachine.PriceFloorParams
 import io.bidmachine.interstitial.InterstitialAd
 import io.bidmachine.interstitial.InterstitialListener
@@ -60,7 +59,7 @@ internal class BMInterstitialAdImpl(
             }
             .setAdContentType(AdContentType.All)
             .setPriceFloorParams(PriceFloorParams().addPriceFloor(adParams.price))
-            .setCustomParams(CustomParams().addParam("mediation_mode", "bidon"))
+            .setCustomParams(adParams.customParameters)
             .setLoadingTimeOut(adParams.timeout.toInt())
             .setListener(
                 object : AdRequest.AdRequestListener<InterstitialRequest> {

--- a/adapter/bidmachine/src/main/java/org/bidon/bidmachine/impl/BMRewardedAdImpl.kt
+++ b/adapter/bidmachine/src/main/java/org/bidon/bidmachine/impl/BMRewardedAdImpl.kt
@@ -3,7 +3,6 @@ package org.bidon.bidmachine.impl
 import android.app.Activity
 import android.content.Context
 import io.bidmachine.AdRequest
-import io.bidmachine.CustomParams
 import io.bidmachine.PriceFloorParams
 import io.bidmachine.rewarded.RewardedAd
 import io.bidmachine.rewarded.RewardedListener
@@ -58,7 +57,7 @@ internal class BMRewardedAdImpl(
                 }
             }
             .setPriceFloorParams(PriceFloorParams().addPriceFloor(adParams.price))
-            .setCustomParams(CustomParams().addParam("mediation_mode", "bidon"))
+            .setCustomParams(adParams.customParameters)
             .setLoadingTimeOut(adParams.timeout.toInt())
             .setListener(
                 object : AdRequest.AdRequestListener<RewardedRequest> {

--- a/adapter/bidmachine/src/main/java/org/bidon/bidmachine/impl/GetAdAuctionParamUseCase.kt
+++ b/adapter/bidmachine/src/main/java/org/bidon/bidmachine/impl/GetAdAuctionParamUseCase.kt
@@ -1,8 +1,10 @@
 package org.bidon.bidmachine.impl
 
+import io.bidmachine.CustomParams
 import org.bidon.bidmachine.BMBannerAuctionParams
 import org.bidon.bidmachine.BMFullscreenAuctionParams
 import org.bidon.sdk.adapter.AdAuctionParamSource
+import org.json.JSONObject
 
 /**
  * Created by Aleksei Cherniaev on 21/11/2023.
@@ -15,7 +17,8 @@ class GetAdAuctionParamUseCase {
                 timeout = adUnit.timeout,
                 context = activity.applicationContext,
                 adUnit = adUnit,
-                payload = adUnit.extra?.optString("payload")
+                payload = adUnit.extra?.optString("payload"),
+                customParameters = buildCustomParameters(adUnit.extra)
             )
         }
     }
@@ -28,8 +31,27 @@ class GetAdAuctionParamUseCase {
                 activity = activity,
                 bannerFormat = bannerFormat,
                 adUnit = adUnit,
-                payload = adUnit.extra?.optString("payload")
+                payload = adUnit.extra?.optString("payload"),
+                customParameters = buildCustomParameters(adUnit.extra)
             )
         }
+    }
+
+    private fun buildCustomParameters(extra: JSONObject?): CustomParams {
+        val customParams = CustomParams().addParam("mediation_mode", "bidon")
+        val paramsJson = extra?.optJSONObject("custom_parameters") ?: return customParams
+
+        try {
+            val keys = paramsJson.keys()
+            while (keys.hasNext()) {
+                val key = keys.next()
+                val value = paramsJson.optString(key)
+                customParams.addParam(key, value)
+            }
+        } catch (_: Throwable) {
+            // ignore
+        }
+
+        return customParams
     }
 }


### PR DESCRIPTION
https://appodeal.atlassian.net/browse/BDN-946

This pull request introduces support for handling `custom_parameters` from the server and passing them to BidMachine SDK ad requests. The changes include updates to the `BidMachineParameters` classes, ad implementations, and the addition of a utility method to process custom parameters. Below are the most significant changes grouped by theme:

### Feature Addition:
* Updated `CHANGELOG.md` to document the new feature: handling `custom_parameters` from the server for BidMachine SDK ad requests.

### Parameter Handling:
* Modified `BMBannerAuctionParams` and `BMFullscreenAuctionParams` classes in `BidMachineParameters.kt` to include a new `customParameters` field of type `CustomParams`. This allows passing custom parameters to ad requests. [[1]](diffhunk://#diff-3f3b38bb528b7b6a9b03dc01ad73610db67551f68f76f213bd9112bdf007e8c8L22-R24) [[2]](diffhunk://#diff-3f3b38bb528b7b6a9b03dc01ad73610db67551f68f76f213bd9112bdf007e8c8L35-R38)

### Ad Request Updates:
* Updated `BMBannerAdImpl`, `BMInterstitialAdImpl`, and `BMRewardedAdImpl` classes to use the `customParameters` field from auction parameters instead of hardcoding `"mediation_mode"`. [[1]](diffhunk://#diff-8dce710116cbf7a3fb326f08642d12c1dad4c6d4ef205e65739bbd79201fcfdfL58-R57) [[2]](diffhunk://#diff-7ee1016cb946b23af4737ed14923755af031f03f97f58cb08a6b0f3044185731L63-R62) [[3]](diffhunk://#diff-873afe6e1ad8af7c7cb5a440ebb3e0e9a57e9cb48f9b1ba204b6a884864849e8L61-R60)

### Utility Method:
* Introduced a `buildCustomParameters` method in `GetAdAuctionParamUseCase.kt` to parse `custom_parameters` from a `JSONObject`. This method ensures all custom parameters from the server are included in the `CustomParams` object.

### Code Cleanup:
* Removed redundant `CustomParams` imports from files where it is no longer directly instantiated. [[1]](diffhunk://#diff-8dce710116cbf7a3fb326f08642d12c1dad4c6d4ef205e65739bbd79201fcfdfL4) [[2]](diffhunk://#diff-7ee1016cb946b23af4737ed14923755af031f03f97f58cb08a6b0f3044185731L7) [[3]](diffhunk://#diff-873afe6e1ad8af7c7cb5a440ebb3e0e9a57e9cb48f9b1ba204b6a884864849e8L6)