### PR TITLE
BDN-949: Refactoring BCAMAX ad caching to support multiple ad units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # develop (2025.*.*)
 ## Features:
 - [BDN-933](https://appodeal.atlassian.net/browse/BDN-933) Added BCA-MAX to Bidon Sdk repository and publish to Bidon artifactory
+- [BDN-949](https://appodeal.atlassian.net/browse/BDN-949) Refactoring BCA-MAX Ad Caching to Support Multiple MAX Ad Units
 
 # 0.7.8 (2025.05.07)
 ## Features:

--- a/thirdPartyMediationAdapters/applovin_max/src/main/java/com/applovin/mediation/adapters/BidonMediationAdapter.kt
+++ b/thirdPartyMediationAdapters/applovin_max/src/main/java/com/applovin/mediation/adapters/BidonMediationAdapter.kt
@@ -12,6 +12,7 @@ import com.applovin.mediation.adapter.parameters.MaxAdapterInitializationParamet
 import com.applovin.mediation.adapters.banner.BidonBanner
 import com.applovin.mediation.adapters.ext.updatePrivacySettings
 import com.applovin.mediation.adapters.interstitial.BidonInterstitial
+import com.applovin.mediation.adapters.keeper.AdKeepers
 import com.applovin.mediation.adapters.rewarded.BidonRewarded
 import com.applovin.sdk.AppLovinSdk
 import org.bidon.sdk.BidonSdk
@@ -38,6 +39,12 @@ internal class BidonMediationAdapter(
     ) {
         BidonSdk.updatePrivacySettings(parameters)
 
+        val context = activity?.applicationContext ?: applicationContext
+
+        // Provide settings to AdKeepers
+        val extraParameters = AppLovinSdk.getInstance(context).settings.extraParameters
+        AdKeepers.withSettings(AdKeepers.Settings.from(extraParameters))
+
         val appKey = parameters.serverParameters.getString("app_id")
         if (BidonSdk.isInitialized()) {
             log("Bidon SDK already initialized")
@@ -46,7 +53,6 @@ internal class BidonMediationAdapter(
             log("Bidon SDK initialization failed: Missing app key")
             onCompletionListener.onCompletion(INITIALIZED_FAILURE, "Missing app key")
         } else {
-            val context = activity?.applicationContext ?: applicationContext
             val isTesting = parameters.isTesting
 
             log("Bidon SDK initializing with app key:$appKey, test mode: $isTesting, context: $context")

--- a/thirdPartyMediationAdapters/applovin_max/src/main/java/com/applovin/mediation/adapters/banner/BidonBanner.kt
+++ b/thirdPartyMediationAdapters/applovin_max/src/main/java/com/applovin/mediation/adapters/banner/BidonBanner.kt
@@ -45,8 +45,7 @@ internal class BidonBanner : MaxAdViewAdapter, Logger by AppLovinSdkLogger {
         maxPlacementId = parameters.thirdPartyAdPlacementId
         maxEcpm = customParameters.getAsDouble("ecpm")
 
-        // Get the appropriate keeper for the ad format
-        val adKeeper = AdKeepers.getBannerKeeper(adFormat)
+        val adKeeper = AdKeepers.getKeeper<BannerAdInstance>(parameters.adUnitId, adFormat)
             .also { this.adKeeper = it }
 
         // Get last registered ecpm

--- a/thirdPartyMediationAdapters/applovin_max/src/main/java/com/applovin/mediation/adapters/banner/BidonBanner.kt
+++ b/thirdPartyMediationAdapters/applovin_max/src/main/java/com/applovin/mediation/adapters/banner/BidonBanner.kt
@@ -23,7 +23,6 @@ import org.bidon.sdk.logs.analytic.AdValue
 internal class BidonBanner : MaxAdViewAdapter, Logger by AppLovinSdkLogger {
 
     private var adInstance: BannerAdInstance? = null
-    private var adKeeper: AdKeeper<BannerAdInstance>? = null
 
     private var maxPlacementId: String = "UNDEFINED"
     private var maxEcpm: Double = 0.0
@@ -46,7 +45,6 @@ internal class BidonBanner : MaxAdViewAdapter, Logger by AppLovinSdkLogger {
         maxEcpm = customParameters.getAsDouble("ecpm")
 
         val adKeeper = AdKeepers.getKeeper<BannerAdInstance>(parameters.adUnitId, adFormat)
-            .also { this.adKeeper = it }
 
         // Get last registered ecpm
         val lastRegisteredEcpm = adKeeper.lastRegisteredEcpm()
@@ -72,7 +70,7 @@ internal class BidonBanner : MaxAdViewAdapter, Logger by AppLovinSdkLogger {
                     format = adFormat,
                     auctionKey = auctionKey,
                 ).also { this.adInstance = it }
-                newAdInstance.setListener(listener.asBidonListener())
+                newAdInstance.setListener(listener.asBidonListener(adKeeper))
                 newAdInstance.addExtra("previous_auction_price", lastRegisteredEcpm)
                 newAdInstance.load(activity)
             }
@@ -92,7 +90,7 @@ internal class BidonBanner : MaxAdViewAdapter, Logger by AppLovinSdkLogger {
                     TAG,
                     "Banner ad loaded $consumeAdInstance from cache, Placement ID: $maxPlacementId"
                 )
-                consumeAdInstance.setListener(listener.asBidonListener())
+                consumeAdInstance.setListener(listener.asBidonListener(adKeeper))
                 consumeAdInstance.show()
                 listener.onAdViewAdLoaded(consumeAdInstance.bannerAd)
             }
@@ -103,19 +101,17 @@ internal class BidonBanner : MaxAdViewAdapter, Logger by AppLovinSdkLogger {
         log(TAG, "Destroying banner ad: $adInstance, Placement ID: $maxPlacementId")
         adInstance?.destroy()
         adInstance = null
-        adKeeper = null
     }
 
-    private fun MaxAdViewAdapterListener.asBidonListener(): BannerListener {
+    private fun MaxAdViewAdapterListener.asBidonListener(adKeeper: AdKeeper<BannerAdInstance>): BannerListener {
         val maxBannerCallback = this
         return object : BannerListener {
             override fun onAdLoaded(ad: Ad, auctionInfo: AuctionInfo) {
                 val loadedAdInstance = this@BidonBanner.adInstance
-                val adKeeper = this@BidonBanner.adKeeper
-                if (loadedAdInstance == null || adKeeper == null) {
+                if (loadedAdInstance == null) {
                     log(
                         TAG,
-                        "Banner ad failed to load: Ad is null or keeper is null, Placement ID: $maxPlacementId"
+                        "Banner ad failed to load: Ad is null, Placement ID: $maxPlacementId"
                     )
                     maxBannerCallback.onAdViewAdLoadFailed(MaxAdapterError.NO_FILL)
                     onDestroy()

--- a/thirdPartyMediationAdapters/applovin_max/src/main/java/com/applovin/mediation/adapters/keeper/AdKeepers.kt
+++ b/thirdPartyMediationAdapters/applovin_max/src/main/java/com/applovin/mediation/adapters/keeper/AdKeepers.kt
@@ -1,35 +1,28 @@
 package com.applovin.mediation.adapters.keeper
 
+import androidx.annotation.VisibleForTesting
 import com.applovin.mediation.MaxAdFormat
 import com.applovin.mediation.adapters.banner.BannerAdInstance
 import com.applovin.mediation.adapters.interstitial.InterstitialAdInstance
 import com.applovin.mediation.adapters.rewarded.RewardedAdInstance
+import java.util.concurrent.ConcurrentHashMap
 
 internal object AdKeepers {
-    val interstitial: AdKeeper<InterstitialAdInstance> by lazy {
-        AdKeeperImpl<InterstitialAdInstance>("Interstitial")
-    }
 
-    val rewarded: AdKeeper<RewardedAdInstance> by lazy {
-        AdKeeperImpl<RewardedAdInstance>("Rewarded")
-    }
+    @VisibleForTesting
+    internal val keepers = ConcurrentHashMap<String, AdKeeper<*>>()
 
-    private val banner: AdKeeper<BannerAdInstance> by lazy {
-        AdKeeperImpl<BannerAdInstance>("Banner")
-    }
-
-    private val mrec: AdKeeper<BannerAdInstance> by lazy {
-        AdKeeperImpl<BannerAdInstance>("MRec")
-    }
-
-    private val leader: AdKeeper<BannerAdInstance> by lazy {
-        AdKeeperImpl<BannerAdInstance>("Leader")
-    }
-
-    fun getBannerKeeper(format: MaxAdFormat): AdKeeper<BannerAdInstance> = when (format) {
-        MaxAdFormat.BANNER -> banner
-        MaxAdFormat.MREC -> mrec
-        MaxAdFormat.LEADER -> leader
-        else -> banner
+    @Suppress("UNCHECKED_CAST")
+    fun <T> getKeeper(maxAdUnitId: String, format: MaxAdFormat): AdKeeper<T> {
+        return keepers.getOrPut(maxAdUnitId) {
+            when (format) {
+                MaxAdFormat.BANNER -> AdKeeperImpl<BannerAdInstance>("Banner_$maxAdUnitId")
+                MaxAdFormat.MREC -> AdKeeperImpl<BannerAdInstance>("MRec_$maxAdUnitId")
+                MaxAdFormat.LEADER -> AdKeeperImpl<BannerAdInstance>("Leader_$maxAdUnitId")
+                MaxAdFormat.INTERSTITIAL -> AdKeeperImpl<InterstitialAdInstance>("Interstitial_$maxAdUnitId")
+                MaxAdFormat.REWARDED -> AdKeeperImpl<RewardedAdInstance>("Rewarded_$maxAdUnitId")
+                else -> throw IllegalArgumentException("Unsupported ad format: $format")
+            }
+        } as AdKeeper<T>
     }
 }

--- a/thirdPartyMediationAdapters/applovin_max/src/main/java/com/applovin/mediation/adapters/keeper/AdKeepers.kt
+++ b/thirdPartyMediationAdapters/applovin_max/src/main/java/com/applovin/mediation/adapters/keeper/AdKeepers.kt
@@ -25,14 +25,12 @@ internal object AdKeepers {
      */
     @Suppress("UNCHECKED_CAST")
     fun <T> getKeeper(maxAdUnitId: String, format: MaxAdFormat): AdKeeper<T> {
-        val key = if (settings.singleKeeperEnabled) format.label else maxAdUnitId
+        val key = if (settings.singleKeeperEnabled) format.label else "${format.label}_$maxAdUnitId"
         return keepers.getOrPut(key) {
             when (format) {
-                MaxAdFormat.BANNER -> AdKeeperImpl<BannerAdInstance>("Banner_$maxAdUnitId")
-                MaxAdFormat.MREC -> AdKeeperImpl<BannerAdInstance>("MRec_$maxAdUnitId")
-                MaxAdFormat.LEADER -> AdKeeperImpl<BannerAdInstance>("Leader_$maxAdUnitId")
-                MaxAdFormat.INTERSTITIAL -> AdKeeperImpl<InterstitialAdInstance>("Interstitial_$maxAdUnitId")
-                MaxAdFormat.REWARDED -> AdKeeperImpl<RewardedAdInstance>("Rewarded_$maxAdUnitId")
+                MaxAdFormat.BANNER, MaxAdFormat.MREC, MaxAdFormat.LEADER -> AdKeeperImpl<BannerAdInstance>(key)
+                MaxAdFormat.INTERSTITIAL -> AdKeeperImpl<InterstitialAdInstance>(key)
+                MaxAdFormat.REWARDED -> AdKeeperImpl<RewardedAdInstance>(key)
                 else -> throw IllegalArgumentException("Unsupported ad format: $format")
             }
         } as AdKeeper<T>

--- a/thirdPartyMediationAdapters/applovin_max/src/test/java/com/applovin/mediation/adapters/keeper/AdKeepersTest.kt
+++ b/thirdPartyMediationAdapters/applovin_max/src/test/java/com/applovin/mediation/adapters/keeper/AdKeepersTest.kt
@@ -5,9 +5,9 @@ import com.applovin.mediation.adapters.banner.BannerAdInstance
 import com.applovin.mediation.adapters.interstitial.InterstitialAdInstance
 import com.applovin.mediation.adapters.rewarded.RewardedAdInstance
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
-import org.junit.Assert.assertNotSame
 import org.junit.Before
 import org.junit.Test
 

--- a/thirdPartyMediationAdapters/applovin_max/src/test/java/com/applovin/mediation/adapters/keeper/AdKeepersTest.kt
+++ b/thirdPartyMediationAdapters/applovin_max/src/test/java/com/applovin/mediation/adapters/keeper/AdKeepersTest.kt
@@ -1,0 +1,76 @@
+package com.applovin.mediation.adapters.keeper
+
+import com.applovin.mediation.MaxAdFormat
+import com.applovin.mediation.adapters.banner.BannerAdInstance
+import com.applovin.mediation.adapters.interstitial.InterstitialAdInstance
+import com.applovin.mediation.adapters.rewarded.RewardedAdInstance
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNotSame
+import org.junit.Before
+import org.junit.Test
+
+class AdKeepersTest {
+
+    private val adUnitId = "test_ad_unit_id"
+
+    @Before
+    fun setup() {
+        // Clear keepers before each test
+        AdKeepers.keepers.clear()
+    }
+
+    @Test
+    fun `getKeeper returns same instance for same ad unit id and format`() {
+        val keeper1 = AdKeepers.getKeeper<BannerAdInstance>(adUnitId, MaxAdFormat.BANNER)
+        val keeper2 = AdKeepers.getKeeper<BannerAdInstance>(adUnitId, MaxAdFormat.BANNER)
+
+        assertSame(keeper1, keeper2)
+    }
+
+    @Test
+    fun `getKeeper returns different instances for different ad unit ids`() {
+        val keeper1 = AdKeepers.getKeeper<BannerAdInstance>("ad_unit_1", MaxAdFormat.BANNER)
+        val keeper2 = AdKeepers.getKeeper<BannerAdInstance>("ad_unit_2", MaxAdFormat.BANNER)
+
+        assertNotNull(keeper1)
+        assertNotNull(keeper2)
+        assert(keeper1 !== keeper2)
+    }
+
+    @Test
+    fun `getKeeper creates correct keeper type for each format`() {
+        // Given
+        val bannerKeeper = AdKeepers.getKeeper<BannerAdInstance>("banner_$adUnitId", MaxAdFormat.BANNER)
+        val mrecKeeper = AdKeepers.getKeeper<BannerAdInstance>("mrec_$adUnitId", MaxAdFormat.MREC)
+        val leaderKeeper = AdKeepers.getKeeper<BannerAdInstance>("leader_$adUnitId", MaxAdFormat.LEADER)
+        val interstitialKeeper = AdKeepers.getKeeper<InterstitialAdInstance>("interstitial_$adUnitId", MaxAdFormat.INTERSTITIAL)
+        val rewardedKeeper = AdKeepers.getKeeper<RewardedAdInstance>("rewarded_$adUnitId", MaxAdFormat.REWARDED)
+
+        // Then
+        assertNotNull(bannerKeeper)
+        assertNotNull(mrecKeeper)
+        assertNotNull(leaderKeeper)
+        assertNotNull(interstitialKeeper)
+        assertNotNull(rewardedKeeper)
+
+        // Verify keeper types
+        assertTrue(bannerKeeper is AdKeeperImpl<BannerAdInstance>)
+        assertTrue(mrecKeeper is AdKeeperImpl<BannerAdInstance>)
+        assertTrue(leaderKeeper is AdKeeperImpl<BannerAdInstance>)
+        assertTrue(interstitialKeeper is AdKeeperImpl<InterstitialAdInstance>)
+        assertTrue(rewardedKeeper is AdKeeperImpl<RewardedAdInstance>)
+
+        // Verify different instances for different formats
+        assertNotSame(bannerKeeper, mrecKeeper)
+        assertNotSame(mrecKeeper, leaderKeeper)
+        assertNotSame(leaderKeeper, interstitialKeeper)
+        assertNotSame(interstitialKeeper, rewardedKeeper)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `getKeeper throws exception for unsupported format`() {
+        AdKeepers.getKeeper<BannerAdInstance>(adUnitId, MaxAdFormat.NATIVE)
+    }
+}

--- a/thirdPartyMediationAdapters/applovin_max/src/test/java/com/applovin/mediation/adapters/mockk/LogMockk.kt
+++ b/thirdPartyMediationAdapters/applovin_max/src/test/java/com/applovin/mediation/adapters/mockk/LogMockk.kt
@@ -1,0 +1,45 @@
+package com.applovin.mediation.adapters.mockk
+
+import android.util.Log
+import io.mockk.every
+import io.mockk.mockkStatic
+
+internal fun mockkLog() {
+    mockkStatic(Log::class)
+    every {
+        Log.d(any(), any())
+    } answers {
+        println("[${firstArg<String>()}]: ${secondArg<String>()}")
+        0
+    }
+    every {
+        Log.e(any(), any(), any())
+    } answers {
+        println("[${firstArg<String>()}]: ${secondArg<String>()}, ${thirdArg<Throwable>()}")
+        0
+    }
+    every {
+        Log.d(any(), any())
+    } answers {
+        println("[${firstArg<String>()}]: ${secondArg<String>()}")
+        0
+    }
+    every {
+        Log.v(any(), any())
+    } answers {
+        println("[${firstArg<String>()}]: ${secondArg<String>()}")
+        0
+    }
+    every {
+        Log.v(any(), any(), any())
+    } answers {
+        println("[${firstArg<String>()}]: ${secondArg<String>()}, ${thirdArg<Throwable>()}")
+        0
+    }
+    every {
+        Log.v(any(), any(), any())
+    } answers {
+        println("[${firstArg<String>()}]: ${secondArg<String>()}, ${thirdArg<Throwable>()}")
+        0
+    }
+}


### PR DESCRIPTION
https://appodeal.atlassian.net/browse/BDN-949

This pull request refactors the ad keeper management system in the AppLovin MAX mediation adapters, improving flexibility and testability. It introduces a unified `getKeeper` method for managing ad instances and updates the related adapter classes and tests accordingly.

### Refactoring of Ad Keeper Management:
* [`AdKeepers.kt`](diffhunk://#diff-20d481882627b74cb9cdda318626542b10811c49966771b1cc62db25bbfe9d73R3-R26): Replaced individual ad keeper properties with a unified `getKeeper` method, backed by a `ConcurrentHashMap`, to dynamically manage ad keepers based on `adUnitId` and `MaxAdFormat`. Removed hardcoded keeper instances and added support for various ad formats.

### Updates to Adapter Classes:
* [`BidonBanner.kt`](diffhunk://#diff-d9f1086b6bfd0afa7921cac34652f60349ea23da9845c3af17deeca836c88472L48-R48): Updated to use the new `getKeeper` method for retrieving banner ad keepers.
* [`BidonInterstitial.kt`](diffhunk://#diff-36fa0ae3b0cec6b26b64f0aa9176998993e83efcb806f53014c08f68cd9b4f6cL22-R26): Refactored to dynamically fetch interstitial ad keepers using `getKeeper` and handle null checks for `adKeeper`. [[1]](diffhunk://#diff-36fa0ae3b0cec6b26b64f0aa9176998993e83efcb806f53014c08f68cd9b4f6cL22-R26) [[2]](diffhunk://#diff-36fa0ae3b0cec6b26b64f0aa9176998993e83efcb806f53014c08f68cd9b4f6cR47-R49) [[3]](diffhunk://#diff-36fa0ae3b0cec6b26b64f0aa9176998993e83efcb806f53014c08f68cd9b4f6cR132-R144)
* [`BidonRewarded.kt`](diffhunk://#diff-36d72c556d6784eb9a4b1da5421d088335164d244150ae911511d7844ef83eabL24-R28): Similar updates as `BidonInterstitial.kt`, ensuring `adKeeper` is dynamically fetched and null-checked. [[1]](diffhunk://#diff-36d72c556d6784eb9a4b1da5421d088335164d244150ae911511d7844ef83eabL24-R28) [[2]](diffhunk://#diff-36d72c556d6784eb9a4b1da5421d088335164d244150ae911511d7844ef83eabR49-R51) [[3]](diffhunk://#diff-36d72c556d6784eb9a4b1da5421d088335164d244150ae911511d7844ef83eabR134-R147)

### Test Enhancements:
* [`AdKeepersTest.kt`](diffhunk://#diff-ff66d4e6ccc3906f81ef1f104bebf30e42b5e49dc970f579f3e78738cb56a8eeR1-R76): Added a new test suite to validate the behavior of the `getKeeper` method, including tests for instance reuse, type correctness, and exception handling for unsupported formats.
* Updated existing tests in `BidonBannerTest.kt`, `BidonInterstitialTest.kt`, and `BidonRewardedTest.kt` to mock the `getKeeper` method and verify its usage. [[1]](diffhunk://#diff-360c1a2360d57f99efd7a48185661128527abb1caec16110a9a4bf480762b82eR35-R48) [[2]](diffhunk://#diff-2fd76f7c84027f78537b717cf25bc872873392467c129c85ca9ef25705ff59faR35-R47) [[3]](diffhunk://#diff-360c1a2360d57f99efd7a48185661128527abb1caec16110a9a4bf480762b82eL94-R109)

### Minor Enhancements:
* Added `mockkLog` utility calls in test setup to streamline logging in tests. [[1]](diffhunk://#diff-360c1a2360d57f99efd7a48185661128527abb1caec16110a9a4bf480762b82eR11) [[2]](diffhunk://#diff-2fd76f7c84027f78537b717cf25bc872873392467c129c85ca9ef25705ff59faR4-R11)