### PR TITLE
Feature/BDN-1094: Start.io Reward and RevenuePaid Events Not Triggered

### DIFF
--- a/adapter/startio/CHANGELOG.md
+++ b/adapter/startio/CHANGELOG.md
@@ -4,4 +4,6 @@ All notable changes to the Start.io adapter will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [5.2.4.1]
+- [BDN-1094](https://appodeal.atlassian.net/browse/BDN-1094) `AdEvent.PaidRevenue` callback for Banner, Interstitial, and Rewarded ad types
+- [BDN-1094](https://appodeal.atlassian.net/browse/BDN-1094) `AdEvent.OnReward` callback for Rewarded Video when video completes

--- a/adapter/startio/build.gradle.kts
+++ b/adapter/startio/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 val adapterSdkVersion = "5.2.4"
-val adapterMinor = 0
+val adapterMinor = 1
 val adapterSemantic = Versions.semanticVersion
 
 val adapterMainVersion = "$adapterSdkVersion.$adapterMinor$adapterSemantic"

--- a/adapter/startio/src/main/java/org/bidon/startio/impl/StartIoBannerImpl.kt
+++ b/adapter/startio/src/main/java/org/bidon/startio/impl/StartIoBannerImpl.kt
@@ -15,6 +15,8 @@ import org.bidon.sdk.adapter.impl.AdEventFlow
 import org.bidon.sdk.adapter.impl.AdEventFlowImpl
 import org.bidon.sdk.ads.banner.BannerFormat
 import org.bidon.sdk.config.BidonError
+import org.bidon.sdk.logs.analytic.AdValue
+import org.bidon.sdk.logs.analytic.Precision
 import org.bidon.sdk.logs.logging.impl.logInfo
 import org.bidon.sdk.stats.StatisticsCollector
 import org.bidon.sdk.stats.impl.StatisticsCollectorImpl
@@ -27,6 +29,7 @@ internal class StartIoBannerImpl :
 
     private var banner: BannerStandard? = null
     private var isLoaded: Boolean = false
+    private var price: Double = 0.0
 
     private var loadListener = object : BannerListener {
         override fun onReceiveAd(ad: View?) {
@@ -51,6 +54,18 @@ internal class StartIoBannerImpl :
 
         override fun onImpression(ad: View?) {
             logInfo(TAG, "Banner ad shown successfully")
+            getAd()?.let { bidonAd ->
+                emitEvent(
+                    AdEvent.PaidRevenue(
+                        ad = bidonAd,
+                        adValue = AdValue(
+                            adRevenue = price / 1000.0,
+                            precision = Precision.Estimated,
+                            currency = AdValue.USD,
+                        )
+                    )
+                )
+            }
         }
 
         override fun onClick(ad: View?) {
@@ -73,6 +88,7 @@ internal class StartIoBannerImpl :
             emitEvent(AdEvent.LoadFailed(BidonError.IncorrectAdUnit(demandId = demandId, message = "payload")))
             return
         }
+        this.price = adParams.price
 
         val adPreferences = AdPreferences().apply { adTag = adParams.tag }
         banner = if (adParams.bannerFormat == BannerFormat.MRec) {

--- a/adapter/startio/src/main/java/org/bidon/startio/impl/StartIoInterstitialImpl.kt
+++ b/adapter/startio/src/main/java/org/bidon/startio/impl/StartIoInterstitialImpl.kt
@@ -13,6 +13,8 @@ import org.bidon.sdk.adapter.AdSource
 import org.bidon.sdk.adapter.impl.AdEventFlow
 import org.bidon.sdk.adapter.impl.AdEventFlowImpl
 import org.bidon.sdk.config.BidonError
+import org.bidon.sdk.logs.analytic.AdValue
+import org.bidon.sdk.logs.analytic.Precision
 import org.bidon.sdk.logs.logging.impl.logInfo
 import org.bidon.sdk.stats.StatisticsCollector
 import org.bidon.sdk.stats.impl.StatisticsCollectorImpl
@@ -24,6 +26,7 @@ internal class StartIoInterstitialImpl :
     StatisticsCollector by StatisticsCollectorImpl() {
 
     private var startAppAd: StartAppAd? = null
+    private var price: Double = 0.0
 
     override val isAdReadyToShow: Boolean
         get() = startAppAd?.state == Ad.AdState.READY
@@ -49,7 +52,19 @@ internal class StartIoInterstitialImpl :
 
         override fun adDisplayed(ad: Ad?) {
             logInfo(TAG, "adDisplayed")
-            getAd()?.let { emitEvent(AdEvent.Shown(it)) }
+            getAd()?.let { bidonAd ->
+                emitEvent(AdEvent.Shown(bidonAd))
+                emitEvent(
+                    AdEvent.PaidRevenue(
+                        ad = bidonAd,
+                        adValue = AdValue(
+                            adRevenue = price / 1000.0,
+                            precision = Precision.Estimated,
+                            currency = AdValue.USD,
+                        )
+                    )
+                )
+            }
         }
 
         override fun adClicked(ad: Ad?) {
@@ -77,6 +92,7 @@ internal class StartIoInterstitialImpl :
             emitEvent(AdEvent.LoadFailed(BidonError.IncorrectAdUnit(demandId = demandId, message = "payload")))
             return
         }
+        this.price = adParams.price
         val startAppAd = StartAppAd(adParams.context)
             .also { this.startAppAd = it }
         startAppAd.loadAd(

--- a/adapter/startio/src/main/java/org/bidon/startio/impl/StartIoRewardedImpl.kt
+++ b/adapter/startio/src/main/java/org/bidon/startio/impl/StartIoRewardedImpl.kt
@@ -13,6 +13,8 @@ import org.bidon.sdk.adapter.AdSource
 import org.bidon.sdk.adapter.impl.AdEventFlow
 import org.bidon.sdk.adapter.impl.AdEventFlowImpl
 import org.bidon.sdk.config.BidonError
+import org.bidon.sdk.logs.analytic.AdValue
+import org.bidon.sdk.logs.analytic.Precision
 import org.bidon.sdk.logs.logging.impl.logInfo
 import org.bidon.sdk.stats.StatisticsCollector
 import org.bidon.sdk.stats.impl.StatisticsCollectorImpl
@@ -24,6 +26,7 @@ internal class StartIoRewardedImpl :
     StatisticsCollector by StatisticsCollectorImpl() {
 
     private var startAppAd: StartAppAd? = null
+    private var price: Double = 0.0
 
     override val isAdReadyToShow: Boolean
         get() = startAppAd?.state == Ad.AdState.READY
@@ -49,7 +52,19 @@ internal class StartIoRewardedImpl :
 
         override fun adDisplayed(ad: Ad?) {
             logInfo(TAG, "adDisplayed")
-            getAd()?.let { emitEvent(AdEvent.Shown(it)) }
+            getAd()?.let { bidonAd ->
+                emitEvent(AdEvent.Shown(bidonAd))
+                emitEvent(
+                    AdEvent.PaidRevenue(
+                        ad = bidonAd,
+                        adValue = AdValue(
+                            adRevenue = price / 1000.0,
+                            precision = Precision.Estimated,
+                            currency = AdValue.USD,
+                        )
+                    )
+                )
+            }
         }
 
         override fun adClicked(ad: Ad?) {
@@ -66,7 +81,15 @@ internal class StartIoRewardedImpl :
 
     override fun show(activity: Activity) {
         if (isAdReadyToShow) {
-            startAppAd?.showAd(showListener)
+            startAppAd?.let { ad ->
+                ad.setVideoListener {
+                    logInfo(TAG, "onVideoCompleted")
+                    getAd()?.let { bidonAd ->
+                        emitEvent(AdEvent.OnReward(bidonAd, null))
+                    }
+                }
+                ad.showAd(showListener)
+            }
         } else {
             emitEvent(AdEvent.ShowFailed(BidonError.AdNotReady))
         }
@@ -77,6 +100,7 @@ internal class StartIoRewardedImpl :
             emitEvent(AdEvent.LoadFailed(BidonError.IncorrectAdUnit(demandId = demandId, message = "payload")))
             return
         }
+        this.price = adParams.price
         val startAppAd = StartAppAd(adParams.context)
             .also { this.startAppAd = it }
         startAppAd.loadAd(


### PR DESCRIPTION
## [5.2.4.1]
- `AdEvent.PaidRevenue` callback for Banner, Interstitial, and Rewarded ad types
- `AdEvent.OnReward` callback for Rewarded Video when video completes

https://appodeal.atlassian.net/browse/BDN-1094