### PR TITLE
Feature/BDN-1157 Fix crash in RawRequestClient when URL connection fails

### DIFF
--- a/bidon/src/main/java/org/bidon/sdk/utils/networking/impl/RawRequestClient.kt
+++ b/bidon/src/main/java/org/bidon/sdk/utils/networking/impl/RawRequestClient.kt
@@ -22,6 +22,15 @@ internal class RawRequestClient {
                 urlConnection = it
             }
             connection.requestRawData(rawRequest)
+        } catch (e: Exception) {
+            Result.success(
+                RawResponse.Failure(
+                    headers = mapOf(),
+                    code = NoResponseCode,
+                    responseBody = null,
+                    httpError = HttpError.UncaughtException(e)
+                )
+            )
         } finally {
             (urlConnection as? HttpURLConnection)?.disconnect()
         }


### PR DESCRIPTION
Add try-catch block in RawRequestClient.execute() to handle exceptions thrown during URL.openConnection() such as MalformedURLException or IOException. Previously these exceptions would crash the app as they were not caught. Now they are properly wrapped in a RawResponse.Failure result with HttpError.UncaughtException.

Fixes: BDN-1157

https://claude.ai/code/session_01Q1hSu8KC9i3HmTVG8rwC4x