### PR TITLE
fix: add bidon-dependabot[bot] to allowed_bots in Claude Code workflow

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -76,6 +76,7 @@ jobs:
           anthropic_api_key: ${{ secrets.CLAUDE_API_KEY_SDK }}
           github_token: ${{ steps.app-token.outputs.token }}
           trigger_phrase: "@claude"
+          allowed_bots: "bidon-dependabot[bot]"
           show_full_output: true
           claude_args: |
             --model claude-sonnet-4-5-20250929


### PR DESCRIPTION
## Summary
- `claude-code-action@v1` blocks non-human actors by default
- When `automation-post-dependabot` posts `@claude` comments via `bidon-dependabot[bot]`, the Claude Code workflow fails with: `Workflow initiated by non-human actor: bidon-dependabot (type: Bot)`
- Adds `allowed_bots: "bidon-dependabot[bot]"` to unblock automated deprecated/build fix flow

## Test plan
- [ ] Merge to develop
- [ ] Trigger `@dependabot recreate` on PR #454 to verify the full automation chain works