### PR TITLE
Fix broken Release Notes URLs in adapter CHANGELOGs

### DIFF
--- a/adapter/dtexchange/CHANGELOG.md
+++ b/adapter/dtexchange/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the DTExchange adapter will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-📋 [Release Notes](https://developer.digitalturbine.com/hc/en-us/articles/360010834177-DT-Exchange-Android-Changelog)
+📋 [Release Notes](https://docs.digitalturbine.com/dt-exchange/publishers/sdk-configuration/integrating-the-android-sdk/dt-exchange-android-changelog)
 
 ## [Unreleased]
 

--- a/adapter/fyber/CHANGELOG.md
+++ b/adapter/fyber/CHANGELOG.md
@@ -4,6 +4,6 @@ All notable changes to the Fyber adapter will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-📋 [Release Notes](https://developer.digitalturbine.com/hc/en-us/articles/16075215437980-FairBid-SDK-Changelog)
+📋 [Release Notes](https://docs.digitalturbine.com/dt-fairbid/fairbid-sdk/fairbid-sdk-changelog/android.md)
 
 ## [Unreleased]

--- a/adapter/ironsource/CHANGELOG.md
+++ b/adapter/ironsource/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the IronSource adapter will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-📋 [Release Notes](https://developers.is.com/ironsource-mobile/android/sdk-change-log/)
+📋 [Release Notes](https://docs.unity.com/en-us/grow/levelplay/sdk/android/changelog)
 
 ## [Unreleased]
 

--- a/adapter/zmaticoo/CHANGELOG.md
+++ b/adapter/zmaticoo/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zmaticoo adapter will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-📋 [Release Notes](https://doc.zmaticoo.com/)
+📋 [Release Notes](https://doc.zmaticoo.com/#/help/en/1801/)
 
 ## [Unreleased]
 


### PR DESCRIPTION
## Summary

Fix 4 dead/redirected `Release Notes` URLs used by `claude-fix-deprecated` and by humans reading adapter CHANGELOGs.

| Adapter | Old URL | Problem | New URL |
|---|---|---|---|
| ironsource | `developers.is.com/ironsource-mobile/android/sdk-change-log/` | 301 → `docs.unity.com/en-us/grow` (LevelPlay migration, lands on generic page) | `docs.unity.com/en-us/grow/levelplay/sdk/android/changelog` |
| dtexchange | `developer.digitalturbine.com/hc/.../360010834177-...` | 302 to new docs host | `docs.digitalturbine.com/dt-exchange/.../dt-exchange-android-changelog` |
| fyber | `developer.digitalturbine.com/hc/.../16075215437980-...` | 302 to new docs host; lands on a hub page without versions | `docs.digitalturbine.com/dt-fairbid/fairbid-sdk/fairbid-sdk-changelog/android.md` |
| zmaticoo | `doc.zmaticoo.com/` | doc root SPA shell only | `doc.zmaticoo.com/#/help/en/1801/` |

All four targets were verified to contain Android-specific changelog entries.

Adapters left as-is in this PR (verified, no action needed):
admob, applovin, bidmachine, chartboost, gam, meta, mobilefuse, moloco, unityads, vungle, yandex.

Known issues outside this PR (need vendor input):
- mintegral — `mintegral.com/en/sdk/` returns 404; no public canonical URL found
- bigoads / taurusx — JS-only SPAs, not readable by `claude-fix-deprecated`
- amazon / appsflyer / startio / inmobi / vkads — bot/SSL/domain-blocked from automated fetchers

## Test plan

- [ ] Open each new URL in a browser and confirm it shows the Android SDK changelog
- [ ] If `claude-fix-deprecated` runs against these adapters next, confirm it can fetch release notes