### PR TITLE
[Parrot] JUNI-3: Implement GMA Adapter for Android Bidon SDK (Interstitial, Rewarded, Banner)"

### DIFF
--- a/adapter/gma/CHANGELOG.md
+++ b/adapter/gma/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to the Google Mobile Ads (GMA) adapter will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+📋 [Release Notes](https://developers.google.com/admob/android/rel-notes)
+
+## [Unreleased]
+
+## [25.2.0.0] - 2026-05-01
+### Added
+- Initial release of GMA adapter
+- Support for Banner, Interstitial, and Rewarded ad formats
+- Adapter.Network (waterfall/CPM) mode

--- a/adapter/gma/build.gradle.kts
+++ b/adapter/gma/build.gradle.kts
@@ -1,0 +1,28 @@
+import ext.ADAPTER_VERSION
+import ext.Versions
+
+plugins {
+    id("adapter")
+}
+
+val adapterSdkVersion = "25.2.0"
+val adapterMinor = 0
+val adapterSemantic = Versions.semanticVersion
+
+val adapterMainVersion = "$adapterSdkVersion.$adapterMinor$adapterSemantic"
+
+publishAdapter {
+    artifactId = "gma-adapter"
+    versionName = adapterMainVersion
+}
+
+android {
+    namespace = "org.bidon.gma"
+    defaultConfig {
+        ADAPTER_VERSION = adapterMainVersion
+    }
+}
+
+dependencies {
+    implementation("com.google.android.gms:play-services-ads:$adapterSdkVersion")
+}

--- a/adapter/gma/proguard-rules-consumer.pro
+++ b/adapter/gma/proguard-rules-consumer.pro
@@ -1,0 +1,4 @@
+-keeppackagenames org.bidon.**
+
+-keep class org.bidon.gma.GmaAdapter { *; }
+-keep class com.google.android.gms.ads.** { *; }

--- a/adapter/gma/src/main/AndroidManifest.xml
+++ b/adapter/gma/src/main/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <meta-data
+            android:name="com.google.android.gms.ads.flag.OPTIMIZE_INITIALIZATION"
+            android:value="true" />
+
+        <meta-data
+            android:name="com.google.android.gms.ads.flag.OPTIMIZE_AD_LOADING"
+            android:value="true"/>
+    </application>
+</manifest>

--- a/adapter/gma/src/main/java/org/bidon/gma/GmaAdapter.kt
+++ b/adapter/gma/src/main/java/org/bidon/gma/GmaAdapter.kt
@@ -1,0 +1,67 @@
+package org.bidon.gma
+
+import android.content.Context
+import com.google.android.gms.ads.MobileAds
+import org.bidon.gma.ext.adapterVersion
+import org.bidon.gma.ext.sdkVersion
+import org.bidon.gma.impl.GmaBannerImpl
+import org.bidon.gma.impl.GmaInterstitialImpl
+import org.bidon.gma.impl.GmaRewardedImpl
+import org.bidon.sdk.adapter.AdProvider
+import org.bidon.sdk.adapter.AdSource
+import org.bidon.sdk.adapter.Adapter
+import org.bidon.sdk.adapter.AdapterInfo
+import org.bidon.sdk.adapter.DemandId
+import org.bidon.sdk.adapter.Initializable
+import org.json.JSONObject
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+internal val GmaDemandId = DemandId("gma")
+
+/**
+ * Google Mobile Ads (GMA) adapter.
+ * Uses plain AdRequest.Builder().build() — no AdMobAdapter mediation bundle.
+ * Don't forget to disable automatic refresh for each AdUnit in the GMA console.
+ */
+@Suppress("unused")
+internal class GmaAdapter :
+    Adapter.Network,
+    Initializable<GmaInitParameters>,
+    AdProvider.Banner<GmaBannerAuctionParams>,
+    AdProvider.Rewarded<GmaFullscreenAdAuctionParams>,
+    AdProvider.Interstitial<GmaFullscreenAdAuctionParams> {
+
+    override val demandId = GmaDemandId
+    override val adapterInfo = AdapterInfo(
+        adapterVersion = adapterVersion,
+        sdkVersion = sdkVersion
+    )
+
+    override suspend fun init(context: Context, configParams: GmaInitParameters): Unit =
+        suspendCoroutine { continuation ->
+            MobileAds.initialize(context) {
+                continuation.resume(Unit)
+            }
+        }
+
+    override fun interstitial(): AdSource.Interstitial<GmaFullscreenAdAuctionParams> {
+        return GmaInterstitialImpl()
+    }
+
+    override fun rewarded(): AdSource.Rewarded<GmaFullscreenAdAuctionParams> {
+        return GmaRewardedImpl()
+    }
+
+    override fun banner(): AdSource.Banner<GmaBannerAuctionParams> {
+        return GmaBannerImpl()
+    }
+
+    override fun parseConfigParam(json: String): GmaInitParameters {
+        val jsonObject = JSONObject(json)
+        return GmaInitParameters(
+            requestAgent = jsonObject.optString("request_agent"),
+            queryInfoType = jsonObject.optString("query_info_type")
+        )
+    }
+}

--- a/adapter/gma/src/main/java/org/bidon/gma/GmaErrorExt.kt
+++ b/adapter/gma/src/main/java/org/bidon/gma/GmaErrorExt.kt
@@ -1,0 +1,28 @@
+package org.bidon.gma
+
+import com.google.android.gms.ads.AdError
+import com.google.android.gms.ads.AdRequest.ERROR_CODE_MEDIATION_NO_FILL
+import com.google.android.gms.ads.AdRequest.ERROR_CODE_NETWORK_ERROR
+import com.google.android.gms.ads.AdRequest.ERROR_CODE_NO_FILL
+import com.google.android.gms.ads.LoadAdError
+import org.bidon.sdk.config.BidonError
+
+internal fun LoadAdError.asBidonError(): BidonError = when (this.code) {
+    ERROR_CODE_NO_FILL,
+    ERROR_CODE_MEDIATION_NO_FILL -> BidonError.NoFill(GmaDemandId)
+    ERROR_CODE_NETWORK_ERROR -> BidonError.NetworkError(GmaDemandId)
+    else -> BidonError.Unspecified(
+        demandId = GmaDemandId,
+        cause = Throwable("Domain: $domain. Message: $message. Code: $code")
+    )
+}
+
+internal fun AdError.asBidonError(): BidonError = when (this.code) {
+    ERROR_CODE_NO_FILL,
+    ERROR_CODE_MEDIATION_NO_FILL -> BidonError.NoFill(GmaDemandId)
+    ERROR_CODE_NETWORK_ERROR -> BidonError.NetworkError(GmaDemandId)
+    else -> BidonError.Unspecified(
+        demandId = GmaDemandId,
+        cause = Throwable("Domain: $domain. Message: $message. Code: $code")
+    )
+}

--- a/adapter/gma/src/main/java/org/bidon/gma/GmaInitParameters.kt
+++ b/adapter/gma/src/main/java/org/bidon/gma/GmaInitParameters.kt
@@ -1,0 +1,51 @@
+package org.bidon.gma
+
+import android.app.Activity
+import com.google.android.gms.ads.AdSize
+import org.bidon.gma.ext.toGmaAdSize
+import org.bidon.sdk.adapter.AdAuctionParams
+import org.bidon.sdk.adapter.AdapterParameters
+import org.bidon.sdk.ads.banner.BannerFormat
+import org.bidon.sdk.auction.models.AdUnit
+
+internal class GmaInitParameters(
+    val requestAgent: String?,
+    val queryInfoType: String?
+) : AdapterParameters
+
+internal sealed interface GmaBannerAuctionParams : AdAuctionParams {
+    val activity: Activity
+    val bannerFormat: BannerFormat
+    val containerWidth: Float
+    val adSize: AdSize get() = bannerFormat.toGmaAdSize()
+
+    class Network(
+        override val activity: Activity,
+        override val bannerFormat: BannerFormat,
+        override val containerWidth: Float,
+        override val adUnit: AdUnit,
+    ) : GmaBannerAuctionParams {
+        override val price: Double = adUnit.pricefloor
+        val adUnitId: String? = adUnit.extra?.getString("ad_unit_id")
+
+        override fun toString(): String {
+            return "GmaBannerAuctionParams($adUnit)"
+        }
+    }
+}
+
+internal sealed interface GmaFullscreenAdAuctionParams : AdAuctionParams {
+    val activity: Activity
+
+    class Network(
+        override val activity: Activity,
+        override val adUnit: AdUnit,
+    ) : GmaFullscreenAdAuctionParams {
+        override val price: Double = adUnit.pricefloor
+        val adUnitId: String? = adUnit.extra?.getString("ad_unit_id")
+
+        override fun toString(): String {
+            return "GmaFullscreenAdAuctionParams($adUnit)"
+        }
+    }
+}

--- a/adapter/gma/src/main/java/org/bidon/gma/ext/AdValueExt.kt
+++ b/adapter/gma/src/main/java/org/bidon/gma/ext/AdValueExt.kt
@@ -1,0 +1,20 @@
+package org.bidon.gma.ext
+
+import org.bidon.sdk.logs.analytic.AdValue
+import org.bidon.sdk.logs.analytic.Precision
+
+internal typealias GoogleAdValue = com.google.android.gms.ads.AdValue
+
+internal fun GoogleAdValue.asBidonAdValue(): AdValue {
+    return AdValue(
+        adRevenue = this.valueMicros / 1_000_000.0,
+        precision = when (this.precisionType) {
+            0 -> Precision.Estimated
+            1 -> Precision.Precise
+            2 -> Precision.Estimated
+            3 -> Precision.Precise
+            else -> Precision.Estimated
+        },
+        currency = AdValue.USD,
+    )
+}

--- a/adapter/gma/src/main/java/org/bidon/gma/ext/Ext.kt
+++ b/adapter/gma/src/main/java/org/bidon/gma/ext/Ext.kt
@@ -1,0 +1,25 @@
+package org.bidon.gma.ext
+
+import com.google.android.gms.ads.AdSize
+import com.google.android.gms.ads.MobileAds
+import org.bidon.gma.BuildConfig
+import org.bidon.sdk.ads.banner.BannerFormat
+import org.bidon.sdk.ads.banner.helper.DeviceInfo.isTablet
+
+internal var adapterVersion = BuildConfig.ADAPTER_VERSION
+internal var sdkVersion = MobileAds.getVersion().toString()
+
+internal fun BannerFormat.toGmaAdSize(): AdSize {
+    return when (this) {
+        BannerFormat.Banner -> AdSize.BANNER
+        BannerFormat.LeaderBoard -> AdSize.LEADERBOARD
+        BannerFormat.MRec -> AdSize.MEDIUM_RECTANGLE
+        BannerFormat.Adaptive -> {
+            if (isTablet) {
+                AdSize.LEADERBOARD
+            } else {
+                AdSize.BANNER
+            }
+        }
+    }
+}

--- a/adapter/gma/src/main/java/org/bidon/gma/impl/GetAdAuctionParamsUseCase.kt
+++ b/adapter/gma/src/main/java/org/bidon/gma/impl/GetAdAuctionParamsUseCase.kt
@@ -1,0 +1,34 @@
+package org.bidon.gma.impl
+
+import org.bidon.gma.GmaBannerAuctionParams
+import org.bidon.gma.GmaFullscreenAdAuctionParams
+import org.bidon.sdk.adapter.AdAuctionParamSource
+import org.bidon.sdk.adapter.AdAuctionParams
+import org.bidon.sdk.ads.AdType
+
+internal class GetAdAuctionParamsUseCase {
+    operator fun invoke(
+        auctionParamsScope: AdAuctionParamSource,
+        adType: AdType
+    ): Result<AdAuctionParams> {
+        return auctionParamsScope {
+            when (adType) {
+                AdType.Banner -> {
+                    GmaBannerAuctionParams.Network(
+                        activity = activity,
+                        bannerFormat = bannerFormat,
+                        containerWidth = containerWidth,
+                        adUnit = adUnit,
+                    )
+                }
+
+                AdType.Interstitial, AdType.Rewarded -> {
+                    GmaFullscreenAdAuctionParams.Network(
+                        activity = activity,
+                        adUnit = adUnit,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/adapter/gma/src/main/java/org/bidon/gma/impl/GetAdRequestUseCase.kt
+++ b/adapter/gma/src/main/java/org/bidon/gma/impl/GetAdRequestUseCase.kt
@@ -1,0 +1,7 @@
+package org.bidon.gma.impl
+
+import com.google.android.gms.ads.AdRequest
+
+internal class GetAdRequestUseCase {
+    operator fun invoke() = AdRequest.Builder().build()
+}

--- a/adapter/gma/src/main/java/org/bidon/gma/impl/GetFullScreenContentCallbackUseCase.kt
+++ b/adapter/gma/src/main/java/org/bidon/gma/impl/GetFullScreenContentCallbackUseCase.kt
@@ -1,0 +1,45 @@
+package org.bidon.gma.impl
+
+import com.google.android.gms.ads.AdError
+import com.google.android.gms.ads.FullScreenContentCallback
+import org.bidon.gma.asBidonError
+import org.bidon.sdk.adapter.AdEvent
+import org.bidon.sdk.adapter.impl.AdEventFlow
+import org.bidon.sdk.ads.Ad
+import org.bidon.sdk.logs.logging.impl.logError
+import org.bidon.sdk.logs.logging.impl.logInfo
+
+internal class GetFullScreenContentCallbackUseCase {
+    fun createCallback(
+        adEventFlow: AdEventFlow,
+        getAd: () -> Ad?,
+        onClosed: () -> Unit
+    ): FullScreenContentCallback {
+        return object : FullScreenContentCallback() {
+            override fun onAdClicked() {
+                logInfo(TAG, "onAdClicked: $this")
+                getAd()?.let { adEventFlow.emitEvent(AdEvent.Clicked(it)) }
+            }
+
+            override fun onAdDismissedFullScreenContent() {
+                logInfo(TAG, "onAdDismissedFullScreenContent: $this")
+                getAd()?.let { adEventFlow.emitEvent(AdEvent.Closed(it)) }
+                onClosed()
+            }
+
+            override fun onAdFailedToShowFullScreenContent(error: AdError) {
+                logError(TAG, "onAdFailedToShowFullScreenContent: $this", error.asBidonError())
+                adEventFlow.emitEvent(AdEvent.ShowFailed(error.asBidonError()))
+            }
+
+            override fun onAdImpression() {
+                logInfo(TAG, "onAdShown: $this")
+                getAd()?.let { adEventFlow.emitEvent(AdEvent.Shown(it)) }
+            }
+
+            override fun onAdShowedFullScreenContent() {}
+        }
+    }
+}
+
+private const val TAG = "GetFullScreenContentCallback"

--- a/adapter/gma/src/main/java/org/bidon/gma/impl/GmaBannerImpl.kt
+++ b/adapter/gma/src/main/java/org/bidon/gma/impl/GmaBannerImpl.kt
@@ -1,0 +1,103 @@
+package org.bidon.gma.impl
+
+import android.annotation.SuppressLint
+import com.google.android.gms.ads.AdListener
+import com.google.android.gms.ads.AdView
+import com.google.android.gms.ads.LoadAdError
+import com.google.android.gms.ads.OnPaidEventListener
+import org.bidon.gma.GmaBannerAuctionParams
+import org.bidon.gma.asBidonError
+import org.bidon.gma.ext.asBidonAdValue
+import org.bidon.sdk.adapter.AdAuctionParamSource
+import org.bidon.sdk.adapter.AdAuctionParams
+import org.bidon.sdk.adapter.AdEvent
+import org.bidon.sdk.adapter.AdSource
+import org.bidon.sdk.adapter.AdViewHolder
+import org.bidon.sdk.adapter.impl.AdEventFlow
+import org.bidon.sdk.adapter.impl.AdEventFlowImpl
+import org.bidon.sdk.config.BidonError
+import org.bidon.sdk.logs.logging.impl.logInfo
+import org.bidon.sdk.stats.StatisticsCollector
+import org.bidon.sdk.stats.impl.StatisticsCollectorImpl
+
+internal class GmaBannerImpl(
+    private val getAdRequest: GetAdRequestUseCase = GetAdRequestUseCase(),
+    private val getAdAuctionParams: GetAdAuctionParamsUseCase = GetAdAuctionParamsUseCase(),
+) : AdSource.Banner<GmaBannerAuctionParams>,
+    AdEventFlow by AdEventFlowImpl(),
+    StatisticsCollector by StatisticsCollectorImpl() {
+
+    override var isAdReadyToShow: Boolean = false
+
+    private var adView: AdView? = null
+
+    override fun getAuctionParam(auctionParamsScope: AdAuctionParamSource): Result<AdAuctionParams> {
+        return getAdAuctionParams(auctionParamsScope, demandAd.adType)
+    }
+
+    @SuppressLint("MissingPermission")
+    override fun load(adParams: GmaBannerAuctionParams) {
+        logInfo(TAG, "Starting with $adParams")
+        val adUnitId: String = when (adParams) {
+            is GmaBannerAuctionParams.Network -> adParams.adUnitId
+        } ?: run {
+            emitEvent(AdEvent.LoadFailed(BidonError.IncorrectAdUnit(demandId = demandId, message = "adUnitId")))
+            return
+        }
+        adParams.activity.runOnUiThread {
+            val adView = AdView(adParams.activity.applicationContext).also {
+                adView = it
+            }
+            val requestListener = object : AdListener() {
+                override fun onAdFailedToLoad(loadAdError: LoadAdError) {
+                    logInfo(TAG, "onAdFailedToLoad: $loadAdError. $this")
+                    emitEvent(AdEvent.LoadFailed(loadAdError.asBidonError()))
+                }
+
+                override fun onAdLoaded() {
+                    logInfo(TAG, "onAdLoaded: $this")
+                    isAdReadyToShow = true
+                    getAd()?.let { emitEvent(AdEvent.Fill(ad = it)) }
+                }
+
+                override fun onAdClicked() {
+                    logInfo(TAG, "onAdClicked: $this")
+                    getAd()?.let { emitEvent(AdEvent.Clicked(it)) }
+                }
+
+                override fun onAdClosed() {
+                    logInfo(TAG, "onAdClosed: $this")
+                    getAd()?.let { emitEvent(AdEvent.Closed(it)) }
+                }
+
+                override fun onAdImpression() {
+                    logInfo(TAG, "onAdImpression: $this")
+                }
+
+                override fun onAdOpened() {}
+            }
+            adView.apply {
+                this.setAdSize(adParams.adSize)
+                this.adUnitId = adUnitId
+                this.adListener = requestListener
+
+                this.onPaidEventListener = OnPaidEventListener { adValue ->
+                    getAd()?.let {
+                        emitEvent(AdEvent.PaidRevenue(it, adValue.asBidonAdValue()))
+                    }
+                }
+                adView.loadAd(getAdRequest())
+            }
+        }
+    }
+
+    override fun getAdView(): AdViewHolder? = adView?.let { AdViewHolder(networkAdview = it) }
+
+    override fun destroy() {
+        logInfo(TAG, "destroy $this")
+        adView?.onPaidEventListener = null
+        adView = null
+    }
+}
+
+private const val TAG = "GmaBanner"

--- a/adapter/gma/src/main/java/org/bidon/gma/impl/GmaInterstitialImpl.kt
+++ b/adapter/gma/src/main/java/org/bidon/gma/impl/GmaInterstitialImpl.kt
@@ -1,0 +1,101 @@
+package org.bidon.gma.impl
+
+import android.app.Activity
+import com.google.android.gms.ads.LoadAdError
+import com.google.android.gms.ads.OnPaidEventListener
+import com.google.android.gms.ads.interstitial.InterstitialAd
+import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback
+import org.bidon.gma.GmaFullscreenAdAuctionParams
+import org.bidon.gma.asBidonError
+import org.bidon.gma.ext.asBidonAdValue
+import org.bidon.sdk.adapter.AdAuctionParamSource
+import org.bidon.sdk.adapter.AdAuctionParams
+import org.bidon.sdk.adapter.AdEvent
+import org.bidon.sdk.adapter.AdSource
+import org.bidon.sdk.adapter.impl.AdEventFlow
+import org.bidon.sdk.adapter.impl.AdEventFlowImpl
+import org.bidon.sdk.config.BidonError
+import org.bidon.sdk.logs.logging.impl.logInfo
+import org.bidon.sdk.stats.StatisticsCollector
+import org.bidon.sdk.stats.impl.StatisticsCollectorImpl
+
+internal class GmaInterstitialImpl(
+    private val getAdRequest: GetAdRequestUseCase = GetAdRequestUseCase(),
+    private val getFullScreenContentCallback: GetFullScreenContentCallbackUseCase = GetFullScreenContentCallbackUseCase(),
+    private val obtainAdAuctionParams: GetAdAuctionParamsUseCase = GetAdAuctionParamsUseCase(),
+) : AdSource.Interstitial<GmaFullscreenAdAuctionParams>,
+    AdEventFlow by AdEventFlowImpl(),
+    StatisticsCollector by StatisticsCollectorImpl() {
+
+    private var interstitialAd: InterstitialAd? = null
+    private var price: Double? = null
+
+    override val isAdReadyToShow: Boolean
+        get() = interstitialAd != null
+
+    override fun getAuctionParam(auctionParamsScope: AdAuctionParamSource): Result<AdAuctionParams> {
+        return obtainAdAuctionParams(auctionParamsScope, demandAd.adType)
+    }
+
+    override fun load(adParams: GmaFullscreenAdAuctionParams) {
+        logInfo(TAG, "Starting with $adParams")
+        val adUnitId = when (adParams) {
+            is GmaFullscreenAdAuctionParams.Network -> adParams.adUnitId
+        } ?: run {
+            emitEvent(
+                AdEvent.LoadFailed(
+                    BidonError.IncorrectAdUnit(demandId = demandId, message = "adUnitId")
+                )
+            )
+            return
+        }
+        price = adParams.price
+        val requestListener = object : InterstitialAdLoadCallback() {
+            override fun onAdFailedToLoad(loadAdError: LoadAdError) {
+                logInfo(TAG, "onAdFailedToLoad: $loadAdError. $this")
+                emitEvent(AdEvent.LoadFailed(loadAdError.asBidonError()))
+            }
+
+            override fun onAdLoaded(interstitialAd: InterstitialAd) {
+                logInfo(TAG, "onAdLoaded: $this")
+                this@GmaInterstitialImpl.interstitialAd = interstitialAd
+                adParams.activity.runOnUiThread {
+                    interstitialAd.onPaidEventListener = OnPaidEventListener { adValue ->
+                        getAd()?.let {
+                            emitEvent(AdEvent.PaidRevenue(it, adValue.asBidonAdValue()))
+                        }
+                    }
+                    interstitialAd.fullScreenContentCallback = getFullScreenContentCallback.createCallback(
+                        adEventFlow = this@GmaInterstitialImpl,
+                        getAd = {
+                            getAd()
+                        },
+                        onClosed = {
+                            this@GmaInterstitialImpl.interstitialAd = null
+                        }
+                    )
+                    getAd()?.let { emitEvent(AdEvent.Fill(it)) }
+                }
+            }
+        }
+        InterstitialAd.load(adParams.activity, adUnitId, getAdRequest(), requestListener)
+    }
+
+    override fun show(activity: Activity) {
+        logInfo(TAG, "Starting show: $this")
+        if (interstitialAd == null) {
+            emitEvent(AdEvent.ShowFailed(BidonError.AdNotReady))
+        } else {
+            interstitialAd?.show(activity)
+        }
+    }
+
+    override fun destroy() {
+        logInfo(TAG, "destroy $this")
+        interstitialAd?.onPaidEventListener = null
+        interstitialAd?.fullScreenContentCallback = null
+        interstitialAd = null
+    }
+}
+
+private const val TAG = "GmaInterstitial"

--- a/adapter/gma/src/main/java/org/bidon/gma/impl/GmaRewardedImpl.kt
+++ b/adapter/gma/src/main/java/org/bidon/gma/impl/GmaRewardedImpl.kt
@@ -1,0 +1,113 @@
+package org.bidon.gma.impl
+
+import android.app.Activity
+import com.google.android.gms.ads.LoadAdError
+import com.google.android.gms.ads.OnPaidEventListener
+import com.google.android.gms.ads.rewarded.RewardedAd
+import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback
+import org.bidon.gma.GmaFullscreenAdAuctionParams
+import org.bidon.gma.asBidonError
+import org.bidon.gma.ext.asBidonAdValue
+import org.bidon.sdk.adapter.AdAuctionParamSource
+import org.bidon.sdk.adapter.AdAuctionParams
+import org.bidon.sdk.adapter.AdEvent
+import org.bidon.sdk.adapter.AdSource
+import org.bidon.sdk.adapter.impl.AdEventFlow
+import org.bidon.sdk.adapter.impl.AdEventFlowImpl
+import org.bidon.sdk.ads.rewarded.Reward
+import org.bidon.sdk.config.BidonError
+import org.bidon.sdk.logs.logging.impl.logInfo
+import org.bidon.sdk.stats.StatisticsCollector
+import org.bidon.sdk.stats.impl.StatisticsCollectorImpl
+
+internal class GmaRewardedImpl(
+    private val getAdRequest: GetAdRequestUseCase = GetAdRequestUseCase(),
+    private val getFullScreenContentCallback: GetFullScreenContentCallbackUseCase = GetFullScreenContentCallbackUseCase(),
+    private val obtainAdAuctionParams: GetAdAuctionParamsUseCase = GetAdAuctionParamsUseCase(),
+) : AdSource.Rewarded<GmaFullscreenAdAuctionParams>,
+    AdEventFlow by AdEventFlowImpl(),
+    StatisticsCollector by StatisticsCollectorImpl() {
+
+    private var rewardedAd: RewardedAd? = null
+    private var price: Double? = null
+
+    override val isAdReadyToShow: Boolean
+        get() = rewardedAd != null
+
+    override fun getAuctionParam(auctionParamsScope: AdAuctionParamSource): Result<AdAuctionParams> {
+        return obtainAdAuctionParams(auctionParamsScope, demandAd.adType)
+    }
+
+    override fun load(adParams: GmaFullscreenAdAuctionParams) {
+        logInfo(TAG, "Starting with $adParams")
+        val adUnitId = when (adParams) {
+            is GmaFullscreenAdAuctionParams.Network -> adParams.adUnitId
+        } ?: run {
+            emitEvent(
+                AdEvent.LoadFailed(
+                    BidonError.IncorrectAdUnit(demandId, "adUnitId")
+                )
+            )
+            return
+        }
+        price = adParams.price
+        val requestListener = object : RewardedAdLoadCallback() {
+            override fun onAdFailedToLoad(loadAdError: LoadAdError) {
+                logInfo(TAG, "onAdFailedToLoad: $loadAdError. $this")
+                emitEvent(AdEvent.LoadFailed(loadAdError.asBidonError()))
+            }
+
+            override fun onAdLoaded(rewardedAd: RewardedAd) {
+                logInfo(TAG, "onAdLoaded. RewardedAd=$rewardedAd, $this")
+                this@GmaRewardedImpl.rewardedAd = rewardedAd
+                adParams.activity.runOnUiThread {
+                    rewardedAd.onPaidEventListener = OnPaidEventListener { adValue ->
+                        getAd()?.let {
+                            emitEvent(
+                                AdEvent.PaidRevenue(
+                                    ad = it,
+                                    adValue = adValue.asBidonAdValue()
+                                )
+                            )
+                        }
+                    }
+                    rewardedAd.fullScreenContentCallback = getFullScreenContentCallback.createCallback(
+                        adEventFlow = this@GmaRewardedImpl,
+                        getAd = {
+                            getAd()
+                        },
+                        onClosed = {
+                            this@GmaRewardedImpl.rewardedAd = null
+                        }
+                    )
+                    getAd()?.let { emitEvent(AdEvent.Fill(it)) }
+                }
+            }
+        }
+        RewardedAd.load(adParams.activity, adUnitId, getAdRequest(), requestListener)
+    }
+
+    override fun show(activity: Activity) {
+        logInfo(TAG, "Starting show: $this")
+        val rewardedAd = rewardedAd
+        if (rewardedAd == null) {
+            emitEvent(AdEvent.ShowFailed(BidonError.AdNotReady))
+        } else {
+            rewardedAd.show(activity) { rewardItem ->
+                logInfo(TAG, "onUserEarnedReward $rewardItem: $this")
+                getAd()?.let {
+                    emitEvent(AdEvent.OnReward(it, Reward(rewardItem.type, rewardItem.amount)))
+                }
+            }
+        }
+    }
+
+    override fun destroy() {
+        logInfo(TAG, "destroy $this")
+        rewardedAd?.onPaidEventListener = null
+        rewardedAd?.fullScreenContentCallback = null
+        rewardedAd = null
+    }
+}
+
+private const val TAG = "GmaRewarded"

--- a/adapter/gma/src/test/java/org/bidon/gma/GmaAdapterApiTest.kt
+++ b/adapter/gma/src/test/java/org/bidon/gma/GmaAdapterApiTest.kt
@@ -1,0 +1,116 @@
+package org.bidon.gma
+
+import com.google.common.truth.Truth.assertThat
+import org.bidon.sdk.adapter.AdProvider
+import org.bidon.sdk.adapter.AdSource
+import org.bidon.sdk.adapter.Adapter
+import org.bidon.sdk.adapter.Initializable
+import org.bidon.sdk.adapter.impl.AdEventFlow
+import org.bidon.sdk.stats.StatisticsCollector
+import org.junit.Test
+import kotlin.test.assertNotNull
+
+class GmaAdapterApiTest {
+
+    private val adapterClass = GmaAdapter::class.java
+
+    @Test
+    fun `adapter implements Adapter_Network interface`() {
+        assertThat(Adapter.Network::class.java.isAssignableFrom(adapterClass)).isTrue()
+    }
+
+    @Test
+    fun `adapter implements Initializable interface`() {
+        assertThat(Initializable::class.java.isAssignableFrom(adapterClass)).isTrue()
+    }
+
+    @Test
+    fun `adapter implements AdProvider_Banner interface`() {
+        assertThat(AdProvider.Banner::class.java.isAssignableFrom(adapterClass)).isTrue()
+    }
+
+    @Test
+    fun `adapter implements AdProvider_Rewarded interface`() {
+        assertThat(AdProvider.Rewarded::class.java.isAssignableFrom(adapterClass)).isTrue()
+    }
+
+    @Test
+    fun `adapter implements AdProvider_Interstitial interface`() {
+        assertThat(AdProvider.Interstitial::class.java.isAssignableFrom(adapterClass)).isTrue()
+    }
+
+    @Test
+    fun `Adapter_Network has required properties`() {
+        val demandIdField = adapterClass.getDeclaredField("demandId")
+        assertNotNull(demandIdField)
+
+        val adapterInfoField = adapterClass.getDeclaredField("adapterInfo")
+        assertNotNull(adapterInfoField)
+    }
+
+    @Test
+    fun `Initializable has required methods`() {
+        val parseConfigParamMethod = adapterClass.getMethod("parseConfigParam", String::class.java)
+        assertNotNull(parseConfigParamMethod)
+    }
+
+    @Test
+    fun `AdProvider_Banner creates valid AdSource_Banner`() {
+        val bannerMethod = adapterClass.getMethod("banner")
+        assertNotNull(bannerMethod)
+        assertThat(AdSource.Banner::class.java.isAssignableFrom(bannerMethod.returnType)).isTrue()
+    }
+
+    @Test
+    fun `AdProvider_Rewarded creates valid AdSource_Rewarded`() {
+        val rewardedMethod = adapterClass.getMethod("rewarded")
+        assertNotNull(rewardedMethod)
+        assertThat(AdSource.Rewarded::class.java.isAssignableFrom(rewardedMethod.returnType)).isTrue()
+    }
+
+    @Test
+    fun `AdProvider_Interstitial creates valid AdSource_Interstitial`() {
+        val interstitialMethod = adapterClass.getMethod("interstitial")
+        assertNotNull(interstitialMethod)
+        assertThat(AdSource.Interstitial::class.java.isAssignableFrom(interstitialMethod.returnType)).isTrue()
+    }
+
+    @Test
+    fun `AdSource_Banner implements required interfaces`() {
+        val bannerImplClass = Class.forName("org.bidon.gma.impl.GmaBannerImpl")
+        assertThat(AdEventFlow::class.java.isAssignableFrom(bannerImplClass)).isTrue()
+        assertThat(StatisticsCollector::class.java.isAssignableFrom(bannerImplClass)).isTrue()
+        assertThat(AdSource.Banner::class.java.isAssignableFrom(bannerImplClass)).isTrue()
+    }
+
+    @Test
+    fun `AdSource_Rewarded implements required interfaces`() {
+        val rewardedImplClass = Class.forName("org.bidon.gma.impl.GmaRewardedImpl")
+        assertThat(AdEventFlow::class.java.isAssignableFrom(rewardedImplClass)).isTrue()
+        assertThat(StatisticsCollector::class.java.isAssignableFrom(rewardedImplClass)).isTrue()
+        assertThat(AdSource.Rewarded::class.java.isAssignableFrom(rewardedImplClass)).isTrue()
+    }
+
+    @Test
+    fun `AdSource_Interstitial implements required interfaces`() {
+        val interstitialImplClass = Class.forName("org.bidon.gma.impl.GmaInterstitialImpl")
+        assertThat(AdEventFlow::class.java.isAssignableFrom(interstitialImplClass)).isTrue()
+        assertThat(StatisticsCollector::class.java.isAssignableFrom(interstitialImplClass)).isTrue()
+        assertThat(AdSource.Interstitial::class.java.isAssignableFrom(interstitialImplClass)).isTrue()
+    }
+
+    @Test
+    fun `AdSource classes have basic structure`() {
+        val bannerImplClass = Class.forName("org.bidon.gma.impl.GmaBannerImpl")
+        val rewardedImplClass = Class.forName("org.bidon.gma.impl.GmaRewardedImpl")
+        val interstitialImplClass = Class.forName("org.bidon.gma.impl.GmaInterstitialImpl")
+
+        assertNotNull(bannerImplClass.constructors)
+        assertNotNull(rewardedImplClass.constructors)
+        assertNotNull(interstitialImplClass.constructors)
+
+        assertThat(bannerImplClass.constructors.isNotEmpty()).isTrue()
+        assertThat(rewardedImplClass.constructors.isNotEmpty()).isTrue()
+        assertThat(interstitialImplClass.constructors.isNotEmpty()).isTrue()
+    }
+}

--- a/bidon/src/main/java/org/bidon/sdk/config/DefaultAdapters.kt
+++ b/bidon/src/main/java/org/bidon/sdk/config/DefaultAdapters.kt
@@ -15,6 +15,7 @@ public enum class DefaultAdapters(public val classPath: String) {
     Chartboost(classPath = "org.bidon.chartboost.ChartboostAdapter"),
     DTExchangeAdapter(classPath = "org.bidon.dtexchange.DTExchangeAdapter"),
     GoogleAdManagerAdapter(classPath = "org.bidon.gam.GamAdapter"),
+    GoogleMobileAdsAdapter(classPath = "org.bidon.gma.GmaAdapter"),
     InmobiAdapter(classPath = "org.bidon.inmobi.InmobiAdapter"),
     IronSourceAdapter(classPath = "org.bidon.ironsource.IronSourceAdapter"),
     MetaAdapter(classPath = "org.bidon.meta.MetaAudienceAdapter"),

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -52,6 +52,7 @@ include(
     ":adapter:chartboost",
     ":adapter:dtexchange",
     ":adapter:gam",
+    ":adapter:gma",
     ":adapter:inmobi",
     ":adapter:ironsource",
     ":adapter:meta",


### PR DESCRIPTION
Implements the new `:adapter:gma` Gradle module for the Bidon Android SDK, providing a GMA (Google Mobile Ads) adapter with demand ID `gma` supporting Banner, Interstitial, and Rewarded ad formats in Adapter.Network (waterfall/CPM) mode.\n\n## JIRA Ticket\n\nJUNI-3 — Implement GMA Adapter for Android Bidon SDK\n\n## Changes\n\n### New Module: adapter/gma/\n\n- `adapter/gma/build.gradle.kts` — Gradle module config (artifactId = gma-adapter, namespace = org.bidon.gma, SDK 25.2.0)\n- `adapter/gma/src/main/AndroidManifest.xml` — GMS optimization meta-data flags\n- `adapter/gma/proguard-rules-consumer.pro` — Keeps GmaAdapter and com.google.android.gms.ads.**\n- `GmaAdapter.kt` — Main adapter: Adapter.Network, Initializable, AdProvider.Banner/Rewarded/Interstitial; demand ID gma\n- `GmaInitParameters.kt` — Init params and auction param sealed interfaces\n- `GmaErrorExt.kt` — Maps LoadAdError/AdError to BidonError\n- `ext/Ext.kt` — adapterVersion, sdkVersion, BannerFormat.toGmaAdSize()\n- `ext/AdValueExt.kt` — GoogleAdValue.asBidonAdValue()\n- `impl/GetAdRequestUseCase.kt` — Plain AdRequest.Builder().build() (no mediation bundle)\n- `impl/GetAdAuctionParamsUseCase.kt` — Dispatches auction params by AdType\n- `impl/GetFullScreenContentCallbackUseCase.kt` — FullScreenContentCallback factory\n- `impl/GmaBannerImpl.kt` — AdSource.Banner using plain AdView\n- `impl/GmaInterstitialImpl.kt` — AdSource.Interstitial using InterstitialAd\n- `impl/GmaRewardedImpl.kt` — AdSource.Rewarded using RewardedAd\n- `CHANGELOG.md` — Initial release entry\n- `src/test/.../GmaAdapterApiTest.kt` — 14 API structure tests\n\n### Modified Files\n\n- `settings.gradle.kts` — Added :adapter:gma after :adapter:gam\n- `bidon/.../DefaultAdapters.kt` — Added GoogleMobileAdsAdapter entry after GoogleAdManagerAdapter\n\n## Architecture Notes\n\n- Uses standard GMS classes (AdView, InterstitialAd, RewardedAd) — not Ad Manager-specific classes\n- GetAdRequestUseCase uses plain AdRequest.Builder().build() — no AdMobAdapter mediation bundle\n- BannerFormat.toGmaAdSize() follows the GAM pattern (no Context arg)\n- emitEvent(AdEvent.LoadFailed(...)) correctly called on null adUnitId guard — fixes the silent bug present in the GAM adapter