### PR TITLE
build: raise demo app minSdk to 24 via TestApp config

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,7 +43,7 @@ android {
     compileSdk = Dependencies.Android.compileSdkVersion
     namespace = defaultPackage
     defaultConfig {
-        minSdk = Dependencies.Android.minSdkVersion
+        minSdk = Dependencies.TestApp.minSdkVersion
         targetSdk = Dependencies.Android.targetSdkVersion
 
         versionCode = 1

--- a/build-logic/convention-plugins/src/main/kotlin/ext/Dependencies.kt
+++ b/build-logic/convention-plugins/src/main/kotlin/ext/Dependencies.kt
@@ -32,6 +32,15 @@ object Dependencies {
         const val Annotation = "androidx.annotation:annotation:1.6.0"
     }
 
+    /**
+     * Demo app config. minSdk is raised above [Android.minSdkVersion] because some bundled
+     * adapter SDKs require a higher minSdk. The core SDK and individual adapters keep
+     * [Android.minSdkVersion].
+     */
+    object TestApp {
+        const val minSdkVersion = 24
+    }
+
     object Java {
         const val javaVersion = 11
         val javaCompile = JvmTarget.JVM_11


### PR DESCRIPTION
## Problem

Some bundled adapter SDKs now require `minSdk 24`, which breaks the demo app manifest merge:

```
uses-sdk:minSdkVersion 23 cannot be smaller than version 24 declared in library ...
> Task :app:processProductionDebugMainManifest FAILED
```

## Change

- Add `Dependencies.TestApp` config with `minSdkVersion = 24`.
- Demo app (`app/build.gradle.kts`) now uses `Dependencies.TestApp.minSdkVersion`.
- Core SDK and individual adapters keep `Android.minSdkVersion` (23).

## Verification

`./gradlew :app:processProductionDebugMainManifest` → BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)