### PR TITLE
Release/0.14.0 to Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-# 0.14.0 (2026.*.*)
+# 0.14.0 (2026.06.10)
+## Features:
 - BDN-1193 Migrated minSdkVersion to API 24
 - BDN-1112 Improved CI workflows and enable Changelog logic for Dependabot automation
 - BDN-1125 Added SDK size check and Claude AI auto-fix deprecated workflows

--- a/build-logic/convention-plugins/src/main/kotlin/ext/Versions.kt
+++ b/build-logic/convention-plugins/src/main/kotlin/ext/Versions.kt
@@ -2,7 +2,7 @@ package ext
 
 object Versions {
     private const val major = 0
-    private const val minor = 13
+    private const val minor = 14
     private const val patch = 0
     private const val semantic: String = ""
 


### PR DESCRIPTION
## Release 0.14.0 (2026.06.10)

### Features
- **BDN-1193** Migrated minSdkVersion to API 24
- **BDN-1112** Improved CI workflows and enabled Changelog logic for Dependabot automation
- **BDN-1125** Added SDK size check and Claude AI auto-fix deprecated workflows
- **BDN-1104** Removed legacy references and standardized file headers

### Adapter updates
Numerous Dependabot adapter SDK bumps (AppLovin, Unity Ads, Yandex, Moloco, Chartboost, BidMachine, IronSource, InMobi, Mintegral, Vungle, BigoAds, Amazon, DTExchange, zMaticoo, TaurusX, VK Ads, MyTarget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)