### PR TITLE
JUNI-5: Implement GMA Next-Gen SDK adapter

### DIFF
--- a/adapter/gma/CHANGELOG.md
+++ b/adapter/gma/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to the GMA Next-Gen SDK adapter will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+📋 [Release Notes](https://developers.google.com/admob/android/next-gen/release-notes)
+
+## [Unreleased]
+
+## [1.1.1.0] - 2026-06-01
+### Added
+- Initial release of GMA Next-Gen SDK adapter
+- Support for Interstitial, Rewarded, and Banner ad formats
+- Adapter.Network (No Bidding) mode

--- a/adapter/gma/build.gradle.kts
+++ b/adapter/gma/build.gradle.kts
@@ -1,0 +1,28 @@
+import ext.ADAPTER_VERSION
+import ext.Versions
+
+plugins {
+    id("adapter")
+}
+
+val adapterSdkVersion = "1.1.1"
+val adapterMinor = 0
+val adapterSemantic = Versions.semanticVersion
+
+val adapterMainVersion = "$adapterSdkVersion.$adapterMinor$adapterSemantic"
+
+publishAdapter {
+    artifactId = "gma-adapter"
+    versionName = adapterMainVersion
+}
+
+android {
+    namespace = "org.bidon.gma"
+    defaultConfig {
+        ADAPTER_VERSION = adapterMainVersion
+    }
+}
+
+dependencies {
+    implementation("com.google.android.libraries.ads.mobile.sdk:ads-mobile-sdk:$adapterSdkVersion")
+}

--- a/adapter/gma/proguard-rules-consumer.pro
+++ b/adapter/gma/proguard-rules-consumer.pro
@@ -1,0 +1,4 @@
+-keeppackagenames org.bidon.**
+
+-keep class org.bidon.gma.GmaAdapter { *; }
+-keep class com.google.android.libraries.ads.mobile.sdk.** { *; }

--- a/adapter/gma/src/main/AndroidManifest.xml
+++ b/adapter/gma/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application />
+</manifest>

--- a/adapter/gma/src/main/java/org/bidon/gma/GmaAdapter.kt
+++ b/adapter/gma/src/main/java/org/bidon/gma/GmaAdapter.kt
@@ -1,0 +1,70 @@
+package org.bidon.gma
+
+import android.content.Context
+import com.google.android.libraries.ads.mobile.sdk.MobileAds
+import com.google.android.libraries.ads.mobile.sdk.initialization.InitializationConfig
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.bidon.gma.ext.adapterVersion
+import org.bidon.gma.ext.sdkVersion
+import org.bidon.gma.impl.GmaBannerImpl
+import org.bidon.gma.impl.GmaInterstitialImpl
+import org.bidon.gma.impl.GmaRewardedImpl
+import org.bidon.sdk.adapter.AdProvider
+import org.bidon.sdk.adapter.AdSource
+import org.bidon.sdk.adapter.Adapter
+import org.bidon.sdk.adapter.AdapterInfo
+import org.bidon.sdk.adapter.DemandId
+import org.bidon.sdk.adapter.Initializable
+import org.json.JSONObject
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+internal val GmaDemandId = DemandId("gma")
+
+/**
+ * [Google Mobile Ads Next-Gen SDK](https://developers.google.com/admob/android/next-gen/quick-start)
+ */
+@Suppress("unused")
+internal class GmaAdapter :
+    Adapter.Network,
+    Initializable<GmaInitParameters>,
+    AdProvider.Banner<GmaBannerAuctionParams>,
+    AdProvider.Rewarded<GmaFullscreenAdAuctionParams>,
+    AdProvider.Interstitial<GmaFullscreenAdAuctionParams> {
+
+    override val demandId = GmaDemandId
+    override val adapterInfo = AdapterInfo(
+        adapterVersion = adapterVersion,
+        sdkVersion = sdkVersion
+    )
+
+    override suspend fun init(context: Context, configParams: GmaInitParameters): Unit =
+        withContext(Dispatchers.IO) {
+            suspendCoroutine { continuation ->
+                val config = InitializationConfig.Builder(configParams.appId ?: "").build()
+                MobileAds.initialize(context, config) {
+                    continuation.resume(Unit)
+                }
+            }
+        }
+
+    override fun interstitial(): AdSource.Interstitial<GmaFullscreenAdAuctionParams> {
+        return GmaInterstitialImpl()
+    }
+
+    override fun rewarded(): AdSource.Rewarded<GmaFullscreenAdAuctionParams> {
+        return GmaRewardedImpl()
+    }
+
+    override fun banner(): AdSource.Banner<GmaBannerAuctionParams> {
+        return GmaBannerImpl()
+    }
+
+    override fun parseConfigParam(json: String): GmaInitParameters {
+        val jsonObject = JSONObject(json)
+        return GmaInitParameters(
+            appId = jsonObject.optString("app_id").takeIf { it.isNotEmpty() }
+        )
+    }
+}

--- a/adapter/gma/src/main/java/org/bidon/gma/GmaErrorExt.kt
+++ b/adapter/gma/src/main/java/org/bidon/gma/GmaErrorExt.kt
@@ -1,0 +1,33 @@
+package org.bidon.gma
+
+import com.google.android.libraries.ads.mobile.sdk.common.AdError
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import org.bidon.sdk.config.BidonError
+
+/**
+ * Error code constants for GMA Next-Gen SDK.
+ * These mirror the legacy GMS SDK error codes.
+ */
+private const val ERROR_CODE_NO_FILL = 3
+private const val ERROR_CODE_NETWORK_ERROR = 2
+private const val ERROR_CODE_MEDIATION_NO_FILL = 9
+
+internal fun LoadAdError.asBidonError(): BidonError = when (this.code) {
+    ERROR_CODE_NO_FILL,
+    ERROR_CODE_MEDIATION_NO_FILL -> BidonError.NoFill(GmaDemandId)
+    ERROR_CODE_NETWORK_ERROR -> BidonError.NetworkError(GmaDemandId)
+    else -> BidonError.Unspecified(
+        demandId = GmaDemandId,
+        cause = Throwable("Domain: $domain. Message: $message. Code: $code")
+    )
+}
+
+internal fun AdError.asBidonError(): BidonError = when (this.code) {
+    ERROR_CODE_NO_FILL,
+    ERROR_CODE_MEDIATION_NO_FILL -> BidonError.NoFill(GmaDemandId)
+    ERROR_CODE_NETWORK_ERROR -> BidonError.NetworkError(GmaDemandId)
+    else -> BidonError.Unspecified(
+        demandId = GmaDemandId,
+        cause = Throwable("Domain: $domain. Message: $message. Code: $code")
+    )
+}

--- a/adapter/gma/src/main/java/org/bidon/gma/GmaInitParameters.kt
+++ b/adapter/gma/src/main/java/org/bidon/gma/GmaInitParameters.kt
@@ -1,0 +1,50 @@
+package org.bidon.gma
+
+import android.app.Activity
+import com.google.android.libraries.ads.mobile.sdk.common.AdSize
+import org.bidon.gma.ext.toGmaAdSize
+import org.bidon.sdk.adapter.AdAuctionParams
+import org.bidon.sdk.adapter.AdapterParameters
+import org.bidon.sdk.ads.banner.BannerFormat
+import org.bidon.sdk.auction.models.AdUnit
+
+internal class GmaInitParameters(
+    val appId: String?
+) : AdapterParameters
+
+internal sealed interface GmaBannerAuctionParams : AdAuctionParams {
+    val activity: Activity
+    val bannerFormat: BannerFormat
+    val containerWidth: Float
+    val adSize: AdSize get() = bannerFormat.toGmaAdSize()
+
+    class Network(
+        override val activity: Activity,
+        override val bannerFormat: BannerFormat,
+        override val containerWidth: Float,
+        override val adUnit: AdUnit,
+    ) : GmaBannerAuctionParams {
+        override val price: Double = adUnit.pricefloor
+        val adUnitId: String? = adUnit.extra?.getString("ad_unit_id")
+
+        override fun toString(): String {
+            return "GmaBannerAuctionParams($adUnit)"
+        }
+    }
+}
+
+internal sealed interface GmaFullscreenAdAuctionParams : AdAuctionParams {
+    val activity: Activity
+
+    class Network(
+        override val activity: Activity,
+        override val adUnit: AdUnit,
+    ) : GmaFullscreenAdAuctionParams {
+        override val price: Double = adUnit.pricefloor
+        val adUnitId: String? = adUnit.extra?.getString("ad_unit_id")
+
+        override fun toString(): String {
+            return "GmaFullscreenAdAuctionParams($adUnit)"
+        }
+    }
+}

--- a/adapter/gma/src/main/java/org/bidon/gma/ext/AdValueExt.kt
+++ b/adapter/gma/src/main/java/org/bidon/gma/ext/AdValueExt.kt
@@ -1,0 +1,20 @@
+package org.bidon.gma.ext
+
+import org.bidon.sdk.logs.analytic.AdValue
+import org.bidon.sdk.logs.analytic.Precision
+
+internal typealias GmaAdValue = com.google.android.libraries.ads.mobile.sdk.common.AdValue
+
+internal fun GmaAdValue.asBidonAdValue(): AdValue {
+    return AdValue(
+        adRevenue = this.valueMicros / 1_000_000.0,
+        precision = when (this.precisionType) {
+            0 -> Precision.Estimated // "UNKNOWN"
+            1 -> Precision.Precise // "PRECISE"
+            2 -> Precision.Estimated // "ESTIMATED"
+            3 -> Precision.Precise // "PUBLISHER_PROVIDED"
+            else -> Precision.Estimated // "unknown type ${precisionType}"
+        },
+        currency = AdValue.USD,
+    )
+}

--- a/adapter/gma/src/main/java/org/bidon/gma/ext/Ext.kt
+++ b/adapter/gma/src/main/java/org/bidon/gma/ext/Ext.kt
@@ -1,0 +1,24 @@
+package org.bidon.gma.ext
+
+import com.google.android.libraries.ads.mobile.sdk.common.AdSize
+import org.bidon.gma.BuildConfig
+import org.bidon.sdk.ads.banner.BannerFormat
+import org.bidon.sdk.ads.banner.helper.DeviceInfo.isTablet
+
+internal var adapterVersion = BuildConfig.ADAPTER_VERSION
+internal var sdkVersion = BuildConfig.ADAPTER_VERSION.substringBeforeLast(".")
+
+internal fun BannerFormat.toGmaAdSize(): AdSize {
+    return when (this) {
+        BannerFormat.Banner -> AdSize.BANNER
+        BannerFormat.LeaderBoard -> AdSize.LEADERBOARD
+        BannerFormat.MRec -> AdSize.MEDIUM_RECTANGLE
+        BannerFormat.Adaptive -> {
+            if (isTablet) {
+                AdSize.LEADERBOARD
+            } else {
+                AdSize.BANNER
+            }
+        }
+    }
+}

--- a/adapter/gma/src/main/java/org/bidon/gma/impl/GetAdAuctionParamsUseCase.kt
+++ b/adapter/gma/src/main/java/org/bidon/gma/impl/GetAdAuctionParamsUseCase.kt
@@ -1,0 +1,35 @@
+package org.bidon.gma.impl
+
+import org.bidon.gma.GmaBannerAuctionParams
+import org.bidon.gma.GmaFullscreenAdAuctionParams
+import org.bidon.sdk.adapter.AdAuctionParamSource
+import org.bidon.sdk.adapter.AdAuctionParams
+import org.bidon.sdk.ads.AdType
+
+internal class GetAdAuctionParamsUseCase {
+    operator fun invoke(
+        auctionParamsScope: AdAuctionParamSource,
+        adType: AdType
+    ): Result<AdAuctionParams> {
+        return auctionParamsScope {
+            when (adType) {
+                AdType.Banner -> {
+                    GmaBannerAuctionParams.Network(
+                        adUnit = adUnit,
+                        bannerFormat = bannerFormat,
+                        activity = activity,
+                        containerWidth = containerWidth,
+                    )
+                }
+
+                AdType.Interstitial,
+                AdType.Rewarded -> {
+                    GmaFullscreenAdAuctionParams.Network(
+                        adUnit = adUnit,
+                        activity = activity,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/adapter/gma/src/main/java/org/bidon/gma/impl/GetAdRequestUseCase.kt
+++ b/adapter/gma/src/main/java/org/bidon/gma/impl/GetAdRequestUseCase.kt
@@ -1,0 +1,8 @@
+package org.bidon.gma.impl
+
+import com.google.android.libraries.ads.mobile.sdk.common.AdRequest
+
+internal class GetAdRequestUseCase {
+    operator fun invoke(adUnitId: String): AdRequest =
+        AdRequest.Builder(adUnitId).build()
+}

--- a/adapter/gma/src/main/java/org/bidon/gma/impl/GetFullScreenContentCallbackUseCase.kt
+++ b/adapter/gma/src/main/java/org/bidon/gma/impl/GetFullScreenContentCallbackUseCase.kt
@@ -1,0 +1,45 @@
+package org.bidon.gma.impl
+
+import com.google.android.libraries.ads.mobile.sdk.common.AdError
+import com.google.android.libraries.ads.mobile.sdk.common.FullScreenContentCallback
+import org.bidon.gma.asBidonError
+import org.bidon.sdk.adapter.AdEvent
+import org.bidon.sdk.adapter.impl.AdEventFlow
+import org.bidon.sdk.ads.Ad
+import org.bidon.sdk.logs.logging.impl.logError
+import org.bidon.sdk.logs.logging.impl.logInfo
+
+internal class GetFullScreenContentCallbackUseCase {
+    fun createCallback(
+        adEventFlow: AdEventFlow,
+        getAd: () -> Ad?,
+        onClosed: () -> Unit
+    ): FullScreenContentCallback {
+        return object : FullScreenContentCallback() {
+            override fun onAdClicked() {
+                logInfo(TAG, "onAdClicked: $this")
+                getAd()?.let { adEventFlow.emitEvent(AdEvent.Clicked(it)) }
+            }
+
+            override fun onAdDismissedFullScreenContent() {
+                logInfo(TAG, "onAdDismissedFullScreenContent: $this")
+                getAd()?.let { adEventFlow.emitEvent(AdEvent.Closed(it)) }
+                onClosed()
+            }
+
+            override fun onAdFailedToShowFullScreenContent(error: AdError) {
+                logError(TAG, "onAdFailedToShowFullScreenContent: $this", error.asBidonError())
+                adEventFlow.emitEvent(AdEvent.ShowFailed(error.asBidonError()))
+            }
+
+            override fun onAdImpression() {
+                logInfo(TAG, "onAdShown: $this")
+                getAd()?.let { adEventFlow.emitEvent(AdEvent.Shown(it)) }
+            }
+
+            override fun onAdShowedFullScreenContent() {}
+        }
+    }
+}
+
+private const val TAG = "GetFullScreenContentCallback"

--- a/adapter/gma/src/main/java/org/bidon/gma/impl/GmaBannerImpl.kt
+++ b/adapter/gma/src/main/java/org/bidon/gma/impl/GmaBannerImpl.kt
@@ -1,0 +1,88 @@
+package org.bidon.gma.impl
+
+import android.annotation.SuppressLint
+import com.google.android.libraries.ads.mobile.sdk.banner.AdView
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAd
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdRequest
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.google.android.libraries.ads.mobile.sdk.common.OnPaidEventListener
+import org.bidon.gma.GmaBannerAuctionParams
+import org.bidon.gma.asBidonError
+import org.bidon.gma.ext.asBidonAdValue
+import org.bidon.sdk.adapter.AdAuctionParamSource
+import org.bidon.sdk.adapter.AdAuctionParams
+import org.bidon.sdk.adapter.AdEvent
+import org.bidon.sdk.adapter.AdSource
+import org.bidon.sdk.adapter.AdViewHolder
+import org.bidon.sdk.adapter.impl.AdEventFlow
+import org.bidon.sdk.adapter.impl.AdEventFlowImpl
+import org.bidon.sdk.ads.AdType
+import org.bidon.sdk.config.BidonError
+import org.bidon.sdk.logs.logging.impl.logInfo
+import org.bidon.sdk.stats.StatisticsCollector
+import org.bidon.sdk.stats.impl.StatisticsCollectorImpl
+
+internal class GmaBannerImpl(
+    private val getAdAuctionParams: GetAdAuctionParamsUseCase = GetAdAuctionParamsUseCase(),
+) : AdSource.Banner<GmaBannerAuctionParams>,
+    AdEventFlow by AdEventFlowImpl(),
+    StatisticsCollector by StatisticsCollectorImpl() {
+
+    override var isAdReadyToShow: Boolean = false
+
+    private var adView: AdView? = null
+
+    override fun getAuctionParam(auctionParamsScope: AdAuctionParamSource): Result<AdAuctionParams> {
+        return getAdAuctionParams(auctionParamsScope, AdType.Banner)
+    }
+
+    @SuppressLint("MissingPermission")
+    override fun load(adParams: GmaBannerAuctionParams) {
+        logInfo(TAG, "Starting with $adParams")
+        val adUnitId = when (adParams) {
+            is GmaBannerAuctionParams.Network -> adParams.adUnitId
+        } ?: run {
+            emitEvent(
+                AdEvent.LoadFailed(
+                    BidonError.IncorrectAdUnit(demandId = demandId, message = "adUnitId")
+                )
+            )
+            return
+        }
+        adParams.activity.runOnUiThread {
+            val adView = AdView(adParams.activity).also {
+                adView = it
+            }
+            val bannerAdRequest = BannerAdRequest.Builder(adUnitId, adParams.adSize).build()
+            val requestListener = object : AdLoadCallback<BannerAd> {
+                override fun onAdFailedToLoad(loadAdError: LoadAdError) {
+                    logInfo(TAG, "onAdFailedToLoad: $loadAdError. $this")
+                    emitEvent(AdEvent.LoadFailed(loadAdError.asBidonError()))
+                }
+
+                override fun onAdLoaded(ad: BannerAd) {
+                    logInfo(TAG, "onAdLoaded: $this")
+                    isAdReadyToShow = true
+                    adView.onPaidEventListener = OnPaidEventListener { adValue ->
+                        getAd()?.let {
+                            emitEvent(AdEvent.PaidRevenue(it, adValue.asBidonAdValue()))
+                        }
+                    }
+                    getAd()?.let { emitEvent(AdEvent.Fill(ad = it)) }
+                }
+            }
+            adView.loadAd(bannerAdRequest, requestListener)
+        }
+    }
+
+    override fun getAdView(): AdViewHolder? = adView?.let { AdViewHolder(it) }
+
+    override fun destroy() {
+        logInfo(TAG, "destroy $this")
+        adView?.onPaidEventListener = null
+        adView = null
+    }
+}
+
+private const val TAG = "GmaBanner"

--- a/adapter/gma/src/main/java/org/bidon/gma/impl/GmaInterstitialImpl.kt
+++ b/adapter/gma/src/main/java/org/bidon/gma/impl/GmaInterstitialImpl.kt
@@ -1,0 +1,102 @@
+package org.bidon.gma.impl
+
+import android.app.Activity
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.google.android.libraries.ads.mobile.sdk.common.OnPaidEventListener
+import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAd
+import org.bidon.gma.GmaFullscreenAdAuctionParams
+import org.bidon.gma.asBidonError
+import org.bidon.gma.ext.asBidonAdValue
+import org.bidon.sdk.adapter.AdAuctionParamSource
+import org.bidon.sdk.adapter.AdAuctionParams
+import org.bidon.sdk.adapter.AdEvent
+import org.bidon.sdk.adapter.AdSource
+import org.bidon.sdk.adapter.impl.AdEventFlow
+import org.bidon.sdk.adapter.impl.AdEventFlowImpl
+import org.bidon.sdk.ads.AdType
+import org.bidon.sdk.config.BidonError
+import org.bidon.sdk.logs.logging.impl.logInfo
+import org.bidon.sdk.stats.StatisticsCollector
+import org.bidon.sdk.stats.impl.StatisticsCollectorImpl
+
+internal class GmaInterstitialImpl(
+    private val getAdRequest: GetAdRequestUseCase = GetAdRequestUseCase(),
+    private val getFullScreenContentCallback: GetFullScreenContentCallbackUseCase = GetFullScreenContentCallbackUseCase(),
+    private val obtainAdAuctionParams: GetAdAuctionParamsUseCase = GetAdAuctionParamsUseCase(),
+) : AdSource.Interstitial<GmaFullscreenAdAuctionParams>,
+    AdEventFlow by AdEventFlowImpl(),
+    StatisticsCollector by StatisticsCollectorImpl() {
+
+    private var interstitialAd: InterstitialAd? = null
+    private var price: Double? = null
+
+    override val isAdReadyToShow: Boolean
+        get() = interstitialAd != null
+
+    override fun getAuctionParam(auctionParamsScope: AdAuctionParamSource): Result<AdAuctionParams> {
+        return obtainAdAuctionParams(auctionParamsScope, AdType.Interstitial)
+    }
+
+    override fun load(adParams: GmaFullscreenAdAuctionParams) {
+        logInfo(TAG, "Starting with $adParams")
+        val adUnitId = when (adParams) {
+            is GmaFullscreenAdAuctionParams.Network -> adParams.adUnitId
+        } ?: run {
+            emitEvent(
+                AdEvent.LoadFailed(
+                    BidonError.IncorrectAdUnit(demandId = demandId, message = "adUnitId")
+                )
+            )
+            return
+        }
+        price = adParams.price
+        val requestListener = object : AdLoadCallback<InterstitialAd> {
+            override fun onAdFailedToLoad(loadAdError: LoadAdError) {
+                logInfo(TAG, "onAdFailedToLoad: $loadAdError. $this")
+                emitEvent(AdEvent.LoadFailed(loadAdError.asBidonError()))
+            }
+
+            override fun onAdLoaded(ad: InterstitialAd) {
+                logInfo(TAG, "onAdLoaded: $this")
+                this@GmaInterstitialImpl.interstitialAd = ad
+                adParams.activity.runOnUiThread {
+                    ad.onPaidEventListener = OnPaidEventListener { adValue ->
+                        getAd()?.let {
+                            emitEvent(AdEvent.PaidRevenue(it, adValue.asBidonAdValue()))
+                        }
+                    }
+                    ad.fullScreenContentCallback = getFullScreenContentCallback.createCallback(
+                        adEventFlow = this@GmaInterstitialImpl,
+                        getAd = {
+                            getAd()
+                        },
+                        onClosed = {
+                            this@GmaInterstitialImpl.interstitialAd = null
+                        }
+                    )
+                    getAd()?.let { emitEvent(AdEvent.Fill(it)) }
+                }
+            }
+        }
+        InterstitialAd.load(getAdRequest(adUnitId), requestListener)
+    }
+
+    override fun show(activity: Activity) {
+        logInfo(TAG, "Starting show: $this")
+        if (interstitialAd == null) {
+            emitEvent(AdEvent.ShowFailed(BidonError.AdNotReady))
+        } else {
+            interstitialAd?.show(activity)
+        }
+    }
+
+    override fun destroy() {
+        logInfo(TAG, "destroy $this")
+        interstitialAd?.onPaidEventListener = null
+        interstitialAd?.fullScreenContentCallback = null
+        interstitialAd = null
+    }
+}
+
+private const val TAG = "GmaInterstitial"

--- a/adapter/gma/src/main/java/org/bidon/gma/impl/GmaRewardedImpl.kt
+++ b/adapter/gma/src/main/java/org/bidon/gma/impl/GmaRewardedImpl.kt
@@ -1,0 +1,114 @@
+package org.bidon.gma.impl
+
+import android.app.Activity
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.google.android.libraries.ads.mobile.sdk.common.OnPaidEventListener
+import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAd
+import org.bidon.gma.GmaFullscreenAdAuctionParams
+import org.bidon.gma.asBidonError
+import org.bidon.gma.ext.asBidonAdValue
+import org.bidon.sdk.adapter.AdAuctionParamSource
+import org.bidon.sdk.adapter.AdAuctionParams
+import org.bidon.sdk.adapter.AdEvent
+import org.bidon.sdk.adapter.AdSource
+import org.bidon.sdk.adapter.impl.AdEventFlow
+import org.bidon.sdk.adapter.impl.AdEventFlowImpl
+import org.bidon.sdk.ads.AdType
+import org.bidon.sdk.ads.rewarded.Reward
+import org.bidon.sdk.config.BidonError
+import org.bidon.sdk.logs.logging.impl.logInfo
+import org.bidon.sdk.stats.StatisticsCollector
+import org.bidon.sdk.stats.impl.StatisticsCollectorImpl
+
+internal class GmaRewardedImpl(
+    private val getAdRequest: GetAdRequestUseCase = GetAdRequestUseCase(),
+    private val getFullScreenContentCallback: GetFullScreenContentCallbackUseCase = GetFullScreenContentCallbackUseCase(),
+    private val obtainAdAuctionParams: GetAdAuctionParamsUseCase = GetAdAuctionParamsUseCase(),
+) : AdSource.Rewarded<GmaFullscreenAdAuctionParams>,
+    AdEventFlow by AdEventFlowImpl(),
+    StatisticsCollector by StatisticsCollectorImpl() {
+
+    private var rewardedAd: RewardedAd? = null
+    private var price: Double? = null
+
+    override val isAdReadyToShow: Boolean
+        get() = rewardedAd != null
+
+    override fun getAuctionParam(auctionParamsScope: AdAuctionParamSource): Result<AdAuctionParams> {
+        return obtainAdAuctionParams(auctionParamsScope, AdType.Rewarded)
+    }
+
+    override fun load(adParams: GmaFullscreenAdAuctionParams) {
+        logInfo(TAG, "Starting with $adParams")
+        val adUnitId = when (adParams) {
+            is GmaFullscreenAdAuctionParams.Network -> adParams.adUnitId
+        } ?: run {
+            emitEvent(
+                AdEvent.LoadFailed(
+                    BidonError.IncorrectAdUnit(demandId = demandId, message = "adUnitId")
+                )
+            )
+            return
+        }
+        price = adParams.price
+        val requestListener = object : AdLoadCallback<RewardedAd> {
+            override fun onAdFailedToLoad(loadAdError: LoadAdError) {
+                logInfo(TAG, "onAdFailedToLoad: $loadAdError. $this")
+                emitEvent(AdEvent.LoadFailed(loadAdError.asBidonError()))
+            }
+
+            override fun onAdLoaded(ad: RewardedAd) {
+                logInfo(TAG, "onAdLoaded. RewardedAd=$ad, $this")
+                this@GmaRewardedImpl.rewardedAd = ad
+                adParams.activity.runOnUiThread {
+                    ad.onPaidEventListener = OnPaidEventListener { adValue ->
+                        getAd()?.let {
+                            emitEvent(
+                                AdEvent.PaidRevenue(
+                                    ad = it,
+                                    adValue = adValue.asBidonAdValue()
+                                )
+                            )
+                        }
+                    }
+                    ad.fullScreenContentCallback = getFullScreenContentCallback.createCallback(
+                        adEventFlow = this@GmaRewardedImpl,
+                        getAd = {
+                            getAd()
+                        },
+                        onClosed = {
+                            this@GmaRewardedImpl.rewardedAd = null
+                        }
+                    )
+                    getAd()?.let { emitEvent(AdEvent.Fill(it)) }
+                }
+            }
+        }
+        RewardedAd.load(getAdRequest(adUnitId), requestListener)
+    }
+
+    override fun show(activity: Activity) {
+        logInfo(TAG, "Starting show: $this")
+        val rewardedAd = rewardedAd
+        if (rewardedAd == null) {
+            emitEvent(AdEvent.ShowFailed(BidonError.AdNotReady))
+        } else {
+            rewardedAd.show(activity) { rewardItem ->
+                logInfo(TAG, "onUserEarnedReward $rewardItem: $this")
+                getAd()?.let {
+                    emitEvent(AdEvent.OnReward(it, Reward(rewardItem.type, rewardItem.amount)))
+                }
+            }
+        }
+    }
+
+    override fun destroy() {
+        logInfo(TAG, "destroy $this")
+        rewardedAd?.onPaidEventListener = null
+        rewardedAd?.fullScreenContentCallback = null
+        rewardedAd = null
+    }
+}
+
+private const val TAG = "GmaRewarded"

--- a/adapter/gma/src/test/java/org/bidon/gma/GmaAdapterApiTest.kt
+++ b/adapter/gma/src/test/java/org/bidon/gma/GmaAdapterApiTest.kt
@@ -1,0 +1,101 @@
+package org.bidon.gma
+
+import com.google.common.truth.Truth.assertThat
+import org.bidon.sdk.adapter.AdProvider
+import org.bidon.sdk.adapter.AdSource
+import org.bidon.sdk.adapter.Adapter
+import org.bidon.sdk.adapter.Initializable
+import org.junit.Test
+import kotlin.test.assertNotNull
+
+class GmaAdapterApiTest {
+
+    private val adapterClass = GmaAdapter::class.java
+
+    @Test
+    fun `adapter implements Adapter_Network interface`() {
+        assertThat(Adapter.Network::class.java.isAssignableFrom(adapterClass)).isTrue()
+    }
+
+    @Test
+    fun `adapter implements Initializable interface`() {
+        assertThat(Initializable::class.java.isAssignableFrom(adapterClass)).isTrue()
+    }
+
+    @Test
+    fun `adapter implements AdProvider_Banner interface`() {
+        assertThat(AdProvider.Banner::class.java.isAssignableFrom(adapterClass)).isTrue()
+    }
+
+    @Test
+    fun `adapter implements AdProvider_Rewarded interface`() {
+        assertThat(AdProvider.Rewarded::class.java.isAssignableFrom(adapterClass)).isTrue()
+    }
+
+    @Test
+    fun `adapter implements AdProvider_Interstitial interface`() {
+        assertThat(AdProvider.Interstitial::class.java.isAssignableFrom(adapterClass)).isTrue()
+    }
+
+    @Test
+    fun `Adapter has required properties`() {
+        val hasDemandIdField = try {
+            adapterClass.getDeclaredField("demandId")
+            true
+        } catch (e: NoSuchFieldException) {
+            false
+        }
+
+        val hasDemandIdGetter = try {
+            adapterClass.getMethod("getDemandId")
+            true
+        } catch (e: NoSuchMethodException) {
+            false
+        }
+
+        assertThat(hasDemandIdField || hasDemandIdGetter).isTrue()
+
+        val hasAdapterInfoField = try {
+            adapterClass.getDeclaredField("adapterInfo")
+            true
+        } catch (e: NoSuchFieldException) {
+            false
+        }
+
+        val hasAdapterInfoGetter = try {
+            adapterClass.getMethod("getAdapterInfo")
+            true
+        } catch (e: NoSuchMethodException) {
+            false
+        }
+
+        assertThat(hasAdapterInfoField || hasAdapterInfoGetter).isTrue()
+    }
+
+    @Test
+    fun `Initializable has required methods`() {
+        val parseConfigParamMethod = adapterClass.getMethod("parseConfigParam", String::class.java)
+        assertNotNull(parseConfigParamMethod)
+    }
+
+    @Test
+    fun `AdProvider_Banner creates valid AdSource_Banner`() {
+        val bannerMethod = adapterClass.getMethod("banner")
+        assertNotNull(bannerMethod)
+        assertThat(AdSource.Banner::class.java.isAssignableFrom(bannerMethod.returnType)).isTrue()
+    }
+
+    @Test
+    fun `AdProvider_Rewarded creates valid AdSource_Rewarded`() {
+        val rewardedMethod = adapterClass.getMethod("rewarded")
+        assertNotNull(rewardedMethod)
+        assertThat(AdSource.Rewarded::class.java.isAssignableFrom(rewardedMethod.returnType)).isTrue()
+    }
+
+    @Test
+    fun `AdProvider_Interstitial creates valid AdSource_Interstitial`() {
+        val interstitialMethod = adapterClass.getMethod("interstitial")
+        assertNotNull(interstitialMethod)
+        assertThat(AdSource.Interstitial::class.java.isAssignableFrom(interstitialMethod.returnType)).isTrue()
+    }
+}

--- a/adapter/gma/src/test/java/org/bidon/gma/impl/GetAdAuctionParamsUseCaseTest.kt
+++ b/adapter/gma/src/test/java/org/bidon/gma/impl/GetAdAuctionParamsUseCaseTest.kt
@@ -1,0 +1,204 @@
+package org.bidon.gma.impl
+
+import android.app.Activity
+import com.google.common.truth.Truth.assertThat
+import io.mockk.mockk
+import org.bidon.gma.GmaBannerAuctionParams
+import org.bidon.gma.GmaFullscreenAdAuctionParams
+import org.bidon.sdk.adapter.AdAuctionParamSource
+import org.bidon.sdk.ads.AdType
+import org.bidon.sdk.ads.banner.BannerFormat
+import org.bidon.sdk.auction.models.AdUnit
+import org.bidon.sdk.stats.models.BidType
+import org.bidon.sdk.utils.json.jsonObject
+import kotlin.test.Test
+
+class GetAdAuctionParamsUseCaseTest {
+
+    private val testee by lazy {
+        GetAdAuctionParamsUseCase()
+    }
+
+    private val activity = mockk<Activity>()
+
+    @Test
+    fun `parse banner AdUnit RTB`() {
+        val auctionParamsScope by lazy {
+            AdAuctionParamSource(
+                activity = activity,
+                pricefloor = 2.6,
+                adUnit = AdUnit(
+                    demandId = "gma",
+                    pricefloor = 2.6,
+                    label = "label123",
+                    bidType = BidType.RTB,
+                    ext = jsonObject {
+                        "ad_unit_id" hasValue "ad_unit_id4"
+                        "payload" hasValue "test_payload"
+                    }.toString(),
+                    timeout = 5000,
+                    uid = "uid123"
+                ),
+                optBannerFormat = BannerFormat.Banner,
+                optContainerWidth = 140f,
+            )
+        }
+        val actual = testee.invoke(
+            auctionParamsScope = auctionParamsScope,
+            adType = AdType.Banner,
+        ).getOrThrow()
+
+        require(actual is GmaBannerAuctionParams.Network)
+        assertThat(actual.adUnit).isEqualTo(
+            AdUnit(
+                demandId = "gma",
+                pricefloor = 2.6,
+                label = "label123",
+                bidType = BidType.RTB,
+                ext = jsonObject {
+                    "ad_unit_id" hasValue "ad_unit_id4"
+                    "payload" hasValue "test_payload"
+                }.toString(),
+                timeout = 5000,
+                uid = "uid123"
+            )
+        )
+        assertThat(actual.price).isEqualTo(2.6)
+        assertThat(actual.adUnitId).isEqualTo("ad_unit_id4")
+    }
+
+    @Test
+    fun `parse banner AdUnit CPM`() {
+        val auctionParamsScope by lazy {
+            AdAuctionParamSource(
+                activity = activity,
+                pricefloor = 3.5,
+                adUnit = AdUnit(
+                    demandId = "gma",
+                    pricefloor = 3.5,
+                    label = "label888",
+                    bidType = BidType.CPM,
+                    ext = jsonObject {
+                        "ad_unit_id" hasValue "ad_unit_id888"
+                    }.toString(),
+                    timeout = 5000,
+                    uid = "uid123"
+                ),
+                optBannerFormat = BannerFormat.MRec,
+                optContainerWidth = 140f,
+            )
+        }
+        val actual = testee.invoke(
+            auctionParamsScope = auctionParamsScope,
+            adType = AdType.Banner,
+        ).getOrThrow()
+
+        require(actual is GmaBannerAuctionParams.Network)
+        assertThat(actual.adUnit).isEqualTo(
+            AdUnit(
+                demandId = "gma",
+                pricefloor = 3.5,
+                label = "label888",
+                bidType = BidType.CPM,
+                ext = jsonObject {
+                    "ad_unit_id" hasValue "ad_unit_id888"
+                }.toString(),
+                timeout = 5000,
+                uid = "uid123"
+            )
+        )
+        assertThat(actual.price).isEqualTo(3.5)
+        assertThat(actual.adUnitId).isEqualTo("ad_unit_id888")
+    }
+
+    @Test
+    fun `parse fullscreen AdUnit RTB`() {
+        val auctionParamsScope by lazy {
+            AdAuctionParamSource(
+                activity = activity,
+                pricefloor = 2.6,
+                adUnit = AdUnit(
+                    demandId = "gma",
+                    pricefloor = 2.6,
+                    label = "label123",
+                    bidType = BidType.RTB,
+                    ext = jsonObject {
+                        "ad_unit_id" hasValue "ad_unit_id4"
+                        "payload" hasValue "test_payload"
+                    }.toString(),
+                    timeout = 5000,
+                    uid = "uid123"
+                ),
+                optBannerFormat = BannerFormat.MRec,
+                optContainerWidth = 140f,
+            )
+        }
+        val actual = testee.invoke(
+            auctionParamsScope = auctionParamsScope,
+            adType = AdType.Rewarded,
+        ).getOrThrow()
+
+        require(actual is GmaFullscreenAdAuctionParams.Network)
+        assertThat(actual.adUnit).isEqualTo(
+            AdUnit(
+                demandId = "gma",
+                pricefloor = 2.6,
+                label = "label123",
+                bidType = BidType.RTB,
+                ext = jsonObject {
+                    "ad_unit_id" hasValue "ad_unit_id4"
+                    "payload" hasValue "test_payload"
+                }.toString(),
+                timeout = 5000,
+                uid = "uid123"
+            )
+        )
+        assertThat(actual.price).isEqualTo(2.6)
+        assertThat(actual.adUnitId).isEqualTo("ad_unit_id4")
+    }
+
+    @Test
+    fun `parse fullscreen AdUnit CPM`() {
+        val auctionParamsScope by lazy {
+            AdAuctionParamSource(
+                activity = activity,
+                pricefloor = 2.75,
+                adUnit = AdUnit(
+                    demandId = "gma",
+                    pricefloor = 3.5,
+                    label = "label888",
+                    bidType = BidType.CPM,
+                    ext = jsonObject {
+                        "ad_unit_id" hasValue "ad_unit_id888"
+                    }.toString(),
+                    timeout = 5000,
+                    uid = "uid123"
+                ),
+                optBannerFormat = null,
+                optContainerWidth = null,
+            )
+        }
+        val actual = testee.invoke(
+            auctionParamsScope = auctionParamsScope,
+            adType = AdType.Interstitial,
+        ).getOrThrow()
+
+        // parse fullscreen AdUnit CPM
+        require(actual is GmaFullscreenAdAuctionParams.Network)
+        assertThat(actual.adUnit).isEqualTo(
+            AdUnit(
+                demandId = "gma",
+                pricefloor = 3.5,
+                label = "label888",
+                bidType = BidType.CPM,
+                ext = jsonObject {
+                    "ad_unit_id" hasValue "ad_unit_id888"
+                }.toString(),
+                timeout = 5000,
+                uid = "uid123"
+            )
+        )
+        assertThat(actual.price).isEqualTo(3.5)
+        assertThat(actual.adUnitId).isEqualTo("ad_unit_id888")
+    }
+}

--- a/bidon/src/main/java/org/bidon/sdk/config/DefaultAdapters.kt
+++ b/bidon/src/main/java/org/bidon/sdk/config/DefaultAdapters.kt
@@ -15,6 +15,7 @@ public enum class DefaultAdapters(public val classPath: String) {
     Chartboost(classPath = "org.bidon.chartboost.ChartboostAdapter"),
     DTExchangeAdapter(classPath = "org.bidon.dtexchange.DTExchangeAdapter"),
     GoogleAdManagerAdapter(classPath = "org.bidon.gam.GamAdapter"),
+    GmaAdapter(classPath = "org.bidon.gma.GmaAdapter"),
     InmobiAdapter(classPath = "org.bidon.inmobi.InmobiAdapter"),
     IronSourceAdapter(classPath = "org.bidon.ironsource.IronSourceAdapter"),
     MetaAdapter(classPath = "org.bidon.meta.MetaAudienceAdapter"),

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -52,6 +52,7 @@ include(
     ":adapter:chartboost",
     ":adapter:dtexchange",
     ":adapter:gam",
+    ":adapter:gma",
     ":adapter:inmobi",
     ":adapter:ironsource",
     ":adapter:meta",


### PR DESCRIPTION
Implements a new adapter:gma module for the Google Mobile Ads (GMA) Next-Gen SDK. This adapter supports Interstitial, Rewarded, and Banner ad formats in Network (No Bidding) mode. Demand ID is gma, distinct from existing admob and gam adapters. Includes 15 new files, 2 modified files, and 2 test files with 13 test cases total.