### PR TITLE
fix(auction): destroy in-flight ad sources on auction cancel (BDN-1192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.15.0 (2026.*.*)
+- BDN-1192 Fixed in-flight ad source leak when destroyAd() is called during an auction
+
 # 0.14.0 (2026.06.10)
 ## Features:
 - BDN-1193 Migrated minSdkVersion to API 24

--- a/bidon/src/main/java/org/bidon/sdk/auction/impl/AuctionImpl.kt
+++ b/bidon/src/main/java/org/bidon/sdk/auction/impl/AuctionImpl.kt
@@ -159,6 +159,10 @@ internal class AuctionImpl(
         if (job?.isActive == true) {
             job?.cancel(AuctionCancellation())
             auctionStat.markAuctionCanceled()
+            // Release in-flight ad sources whose load() was dispatched to the ad-network SDK.
+            // Cancelling the coroutine does not stop the adapter listener flow, so without this
+            // the loaded ad object and its listeners leak (BDN-1192).
+            executeAuction.destroyStartedAdSources()
             logInfo(TAG, "Auction canceled")
         }
         job = null

--- a/bidon/src/main/java/org/bidon/sdk/auction/usecases/ExecuteAuctionUseCase.kt
+++ b/bidon/src/main/java/org/bidon/sdk/auction/usecases/ExecuteAuctionUseCase.kt
@@ -23,4 +23,11 @@ internal interface ExecuteAuctionUseCase {
         resultsCollector: ResultsCollector,
         tokens: Map<String, TokenInfo>
     )
+
+    /**
+     * Destroys every [org.bidon.sdk.adapter.AdSource] whose [org.bidon.sdk.adapter.AdSource.load]
+     * has been started during the current auction. Used to release in-flight ad sources when the
+     * auction is cancelled (e.g. via `destroyAd()`), so adapter-level resources are not leaked.
+     */
+    fun destroyStartedAdSources()
 }

--- a/bidon/src/main/java/org/bidon/sdk/auction/usecases/impl/ExecuteAuctionUseCaseImpl.kt
+++ b/bidon/src/main/java/org/bidon/sdk/auction/usecases/impl/ExecuteAuctionUseCaseImpl.kt
@@ -1,5 +1,8 @@
 package org.bidon.sdk.auction.usecases.impl
 
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.getAndUpdate
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withTimeoutOrNull
 import org.bidon.sdk.adapter.AdAuctionParams
 import org.bidon.sdk.adapter.AdProvider
@@ -37,6 +40,12 @@ internal class ExecuteAuctionUseCaseImpl(
 ) : ExecuteAuctionUseCase {
 
     private var adUnitQueue: LinkedList<AdUnit> = LinkedList()
+
+    /**
+     * Every [AdSource] whose [AdSource.load] has been started during this auction.
+     * Kept so the in-flight sources can be destroyed if the auction is cancelled.
+     */
+    private val startedAdSources = MutableStateFlow(emptyList<AdSource<AdAuctionParams>>())
 
     override suspend fun invoke(
         auctionId: String,
@@ -99,6 +108,7 @@ internal class ExecuteAuctionUseCaseImpl(
                     }
 
                     if (adSource != null) {
+                        startedAdSources.update { it + adSource }
                         applyParams(
                             auctionId = auctionId,
                             auctionConfigurationId = auctionConfigurationId,
@@ -172,6 +182,14 @@ internal class ExecuteAuctionUseCaseImpl(
                 status = it.asBidonErrorOrUnspecified().asRoundStatus()
             )
             logError(TAG, "Failed to execute auction", it)
+        }
+    }
+
+    override fun destroyStartedAdSources() {
+        val sources = startedAdSources.getAndUpdate { emptyList() }
+        if (sources.isNotEmpty()) {
+            logInfo(TAG, "Destroying ${sources.size} in-flight ad source(s) on cancel")
+            sources.forEach { it.destroy() }
         }
     }
 

--- a/bidon/src/test/java/org/bidon/sdk/auction/impl/ExecuteAuctionUseCaseImplTest.kt
+++ b/bidon/src/test/java/org/bidon/sdk/auction/impl/ExecuteAuctionUseCaseImplTest.kt
@@ -1,15 +1,27 @@
 package org.bidon.sdk.auction.impl
 
 import android.app.Activity
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.bidon.sdk.adapter.AdAuctionParams
+import org.bidon.sdk.adapter.AdProvider
+import org.bidon.sdk.adapter.AdSource
+import org.bidon.sdk.adapter.Adapter
 import org.bidon.sdk.adapter.AdaptersSource
+import org.bidon.sdk.adapter.DemandAd
 import org.bidon.sdk.adapter.DemandId
+import org.bidon.sdk.ads.AdType
 import org.bidon.sdk.ads.banner.helper.DeviceInfo
+import org.bidon.sdk.auction.AdTypeParam
+import org.bidon.sdk.auction.ResultsCollector
 import org.bidon.sdk.auction.models.AdUnit
 import org.bidon.sdk.auction.models.AuctionResponse
+import org.bidon.sdk.auction.models.AuctionResult
 import org.bidon.sdk.auction.usecases.ExecuteAuctionUseCase
 import org.bidon.sdk.auction.usecases.RequestAdUnitUseCase
 import org.bidon.sdk.auction.usecases.impl.ExecuteAuctionUseCaseImpl
@@ -23,54 +35,59 @@ import org.bidon.sdk.config.models.base.ConcurrentTest
 import org.bidon.sdk.mockkLog
 import org.bidon.sdk.regulation.Regulation
 import org.bidon.sdk.stats.models.BidType
+import org.bidon.sdk.stats.models.RoundStatus
 import org.bidon.sdk.utils.di.DI
+import org.bidon.sdk.utils.di.SimpleDiStorage
 import org.bidon.sdk.utils.json.jsonObject
 import org.junit.After
 import org.junit.Before
+import org.junit.Test
 /**
  * Created by Bidon Team on 02/07/2024.
  */
 internal class ExecuteAuctionUseCaseImplTest : ConcurrentTest() {
 
-    private val auctionConfig = AuctionResponse(
-        adUnits = listOf(
-            AdUnit(
-                demandId = "admob",
-                label = "admob_banner",
-                pricefloor = 0.25,
-                uid = "12387837129819",
-                bidType = BidType.CPM,
-                timeout = 5000,
-                ext = jsonObject { "ad_unit_id" hasValue "ca-app-pub-3940256099942544/6300978111" }.toString(),
+    private val auctionConfig by lazy {
+        AuctionResponse(
+            adUnits = listOf(
+                AdUnit(
+                    demandId = "admob",
+                    label = "admob_banner",
+                    pricefloor = 0.25,
+                    uid = "12387837129819",
+                    bidType = BidType.CPM,
+                    timeout = 5000,
+                    ext = jsonObject { "ad_unit_id" hasValue "ca-app-pub-3940256099942544/6300978111" }.toString(),
+                ),
+                AdUnit(
+                    demandId = "bidmachine",
+                    label = "bidmachine_banner",
+                    uid = "32387837129819",
+                    pricefloor = 0.0,
+                    bidType = BidType.CPM,
+                    timeout = 5000,
+                    ext = null,
+                )
             ),
-            AdUnit(
-                demandId = "bidmachine",
-                label = "bidmachine_banner",
-                uid = "32387837129819",
-                pricefloor = 0.0,
-                bidType = BidType.CPM,
-                timeout = 5000,
-                ext = null,
-            )
-        ),
-        pricefloor = 0.01,
-        auctionId = "auctionId_123",
-        auctionConfigurationId = 10,
-        auctionConfigurationUid = "10",
-        externalWinNotificationsEnabled = true,
-        auctionTimeout = 10000L,
-        noBids = listOf(
-            AdUnit(
-                bidType = BidType.RTB,
-                demandId = "dem7",
-                label = "dem7_label",
-                pricefloor = 0.021,
-                uid = "123567",
-                timeout = 5000L,
-                ext = ""
+            pricefloor = 0.01,
+            auctionId = "auctionId_123",
+            auctionConfigurationId = 10,
+            auctionConfigurationUid = "10",
+            externalWinNotificationsEnabled = true,
+            auctionTimeout = 10000L,
+            noBids = listOf(
+                AdUnit(
+                    bidType = BidType.RTB,
+                    demandId = "dem7",
+                    label = "dem7_label",
+                    pricefloor = 0.021,
+                    uid = "123567",
+                    timeout = 5000L,
+                    ext = ""
+                )
             )
         )
-    )
+    }
 
     private val activity: Activity by lazy { mockk(relaxed = true) }
     private val adaptersSource: AdaptersSource = mockk()
@@ -114,6 +131,53 @@ internal class ExecuteAuctionUseCaseImplTest : ConcurrentTest() {
     @After
     fun after() {
         unmockkAll()
+        SimpleDiStorage.instances.clear()
+    }
+
+    @Test
+    fun `it should destroy started ad sources on destroyStartedAdSources`() = runTest {
+        // PREPARE: one interstitial adapter whose ad source we can observe
+        val adSource = mockk<AdSource.Interstitial<AdAuctionParams>>(relaxed = true)
+        val adapter = mockk<Adapter>(moreInterfaces = arrayOf(AdProvider.Interstitial::class))
+        every { adapter.demandId } returns DemandId(Admob)
+        @Suppress("UNCHECKED_CAST")
+        every { (adapter as AdProvider.Interstitial<AdAuctionParams>).interstitial() } returns adSource
+        every { adaptersSource.adapters } returns setOf(adapter)
+
+        coEvery {
+            requestAdUnit.invoke(any(), any(), any(), any())
+        } returns AuctionResult.Network(adSource, RoundStatus.Successful)
+
+        val resultsCollector = mockk<ResultsCollector>(relaxed = true)
+
+        // WHEN the auction runs and then is canceled
+        testee.invoke(
+            auctionId = "auctionId_123",
+            auctionConfigurationId = 10,
+            auctionConfigurationUid = "10",
+            externalWinNotificationsEnabled = false,
+            demandAd = DemandAd(AdType.Interstitial),
+            adTypeParam = AdTypeParam.Interstitial(activity, 0.5, null),
+            pricefloor = 0.5,
+            auctionTimeout = 10_000L,
+            adUnits = listOf(
+                AdUnit(
+                    demandId = Admob,
+                    label = "admob_interstitial",
+                    pricefloor = 1.0,
+                    uid = "1",
+                    bidType = BidType.CPM,
+                    timeout = 5000,
+                    ext = null,
+                )
+            ),
+            resultsCollector = resultsCollector,
+            tokens = emptyMap(),
+        )
+        testee.destroyStartedAdSources()
+
+        // THEN the started ad source is destroyed (BDN-1192)
+        verify { adSource.destroy() }
     }
 
 //    @Test

--- a/bidon/src/test/java/org/bidon/sdk/config/models/auctions/impl/AuctionImplTest.kt
+++ b/bidon/src/test/java/org/bidon/sdk/config/models/auctions/impl/AuctionImplTest.kt
@@ -7,7 +7,9 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.slot
+import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
 import org.bidon.sdk.adapter.AdaptersSource
 import org.bidon.sdk.adapter.DemandAd
@@ -374,6 +376,35 @@ internal class AuctionImplTest : ConcurrentTest() {
                 assertThat(throwable).isEqualTo(BidonError.NoAuctionResults)
             }
         )
+    }
+
+    @Test
+    fun `it should destroy started ad sources when auction is canceled`() = runTest {
+        // PREPARE: park the auction inside getTokens so the job stays active (in progress)
+        every { adaptersSource.adapters } returns emptySet()
+        coEvery {
+            tokenGetter.invoke(any(), any(), any())
+        } coAnswers {
+            delay(60_000L)
+            emptyMap()
+        }
+
+        testee.start(
+            demandAd = DemandAd(AdType.Interstitial),
+            adTypeParam = AdTypeParam.Interstitial(
+                activity = activity,
+                pricefloor = 1.0,
+                auctionKey = null
+            ),
+            onSuccess = { _, _ -> error("unexpected") },
+            onFailure = { _, _ -> },
+        )
+
+        // WHEN the auction is canceled while in progress
+        testee.cancel()
+
+        // THEN in-flight ad sources are released (BDN-1192)
+        verify { executeAuctionUseCase.destroyStartedAdSources() }
     }
 
     private fun getAuctionResponse() = AuctionResponse(


### PR DESCRIPTION
## BDN-1192 — In-flight AdSource leak on `destroyAd()` during auction

Jira: https://appodeal.atlassian.net/browse/BDN-1192
Origin: APDM-2443 (Q1 — Create+Load+Dispose while auction in progress)

### Problem
When `destroyAd()` was called while an auction was still loading, ad sources whose `load()` had already been dispatched to the network SDK were never destroyed. `AuctionImpl.cancel()` only cancelled the coroutine `job`; adapter SDKs (e.g. BidMachine) keep their own listener flow running, eventually deliver `onAdLoaded`, and leak the ad request + loaded ad object (and waste bid spend).

### Fix
- `ExecuteAuctionUseCase` tracks every `AdSource` whose `load()` has been started during the auction.
- `AuctionImpl.cancel()` calls `destroyStartedAdSources()`, releasing adapter-level resources for both the in-flight source and any already-loaded-but-uncached sources.

Platform-level (cancellation path is shared) → covers Interstitial / Rewarded / Banner.

### Tests
- `ExecuteAuctionUseCaseImplTest` — started source is destroyed via `destroyStartedAdSources()`.
- `AuctionImplTest` — `cancel()` of an in-progress auction triggers `destroyStartedAdSources()`.

### Validation
`:bidon:ktlintCheck`, `:bidon:assembleProductionRelease`, `:bidon:testProductionReleaseUnitTest` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)