### PR TITLE
Feature/BDN-1198: Add adaptive banner support to Moloco adapter

### DIFF
--- a/adapter/moloco/CHANGELOG.md
+++ b/adapter/moloco/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-## [4.10.0.1] - 2026-07-01
+## [4.10.0.1] - 2026-07-07
 ### Added
 - Added support for adaptive banners
 

--- a/adapter/moloco/CHANGELOG.md
+++ b/adapter/moloco/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [4.10.0.1] - 2026-07-01
+### Added
+- Added support for adaptive banners
+
 ## [4.10.0.0] - 2026-07-01
 ### Changed
 - Updated SDK dependency from 4.9.0 to 4.10.0

--- a/adapter/moloco/build.gradle.kts
+++ b/adapter/moloco/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 val adapterSdkVersion = "4.10.0"
-val adapterMinor = 0
+val adapterMinor = 1
 val adapterSemantic = Versions.semanticVersion
 
 val adapterMainVersion = "$adapterSdkVersion.$adapterMinor$adapterSemantic"

--- a/adapter/moloco/src/main/java/org/bidon/moloco/ext/Ext.kt
+++ b/adapter/moloco/src/main/java/org/bidon/moloco/ext/Ext.kt
@@ -1,6 +1,7 @@
 package org.bidon.moloco.ext
 
 import com.moloco.sdk.publisher.Banner
+import com.moloco.sdk.publisher.BannerAdSize
 import com.moloco.sdk.publisher.MediationInfo
 import com.moloco.sdk.publisher.Moloco
 import com.moloco.sdk.publisher.MolocoAdError
@@ -8,6 +9,7 @@ import org.bidon.moloco.EMPTY_MEDIATOR
 import org.bidon.moloco.EMPTY_WATERMARK
 import org.bidon.moloco.MolocoDemandId
 import org.bidon.sdk.ads.banner.BannerFormat
+import org.bidon.sdk.ads.banner.helper.DeviceInfo
 import org.bidon.sdk.config.BidonError
 
 internal fun MolocoAdError.toBidonLoadError() = when (errorType) {
@@ -26,7 +28,7 @@ internal fun MolocoAdError.toBidonShowError() = when (errorType) {
 }
 
 internal fun Moloco.createBannerAd(
-    bannerSize: BannerFormat,
+    bannerFormat: BannerFormat,
     adUnitId: String,
     callback: (Banner?, Throwable?) -> Unit
 ) {
@@ -35,7 +37,7 @@ internal fun Moloco.createBannerAd(
             callback(banner, null)
         } else {
             val exception = Exception(
-                "${bannerSize.name} wasn't created. " +
+                "${bannerFormat.name} wasn't created. " +
                     "Error: ${err?.description}, code: ${err?.errorCode}"
             )
             callback(null, exception)
@@ -43,7 +45,7 @@ internal fun Moloco.createBannerAd(
     }
 
     try {
-        when (bannerSize) {
+        when (bannerFormat) {
             BannerFormat.Banner -> {
                 Moloco.createBanner(
                     mediationInfo = MediationInfo(EMPTY_MEDIATOR),
@@ -72,7 +74,14 @@ internal fun Moloco.createBannerAd(
             }
 
             BannerFormat.Adaptive -> {
-                callback(null, IllegalStateException("Adaptive format should have been resolved"))
+                Moloco.createMolocoBanner(
+                    mediationInfo = MediationInfo(EMPTY_MEDIATOR),
+                    adUnitId = adUnitId,
+                    // null width lets Moloco auto-detect the full screen width
+                    size = BannerAdSize.AnchoredAdaptive(DeviceInfo.screenWidthDp.takeIf { it > 0 }),
+                    watermarkString = EMPTY_WATERMARK,
+                    callback = sdkCallback
+                )
             }
         }
     } catch (t: Throwable) {

--- a/adapter/moloco/src/main/java/org/bidon/moloco/impl/MolocoAuctionParams.kt
+++ b/adapter/moloco/src/main/java/org/bidon/moloco/impl/MolocoAuctionParams.kt
@@ -2,7 +2,6 @@ package org.bidon.moloco.impl
 
 import org.bidon.sdk.adapter.AdAuctionParams
 import org.bidon.sdk.ads.banner.BannerFormat
-import org.bidon.sdk.ads.banner.helper.DeviceInfo.isTablet
 import org.bidon.sdk.auction.models.AdUnit
 
 internal class MolocoFullscreenAuctionParams(
@@ -14,17 +13,10 @@ internal class MolocoFullscreenAuctionParams(
 }
 
 internal class MolocoBannerAuctionParams(
-    private val bannerFormat: BannerFormat,
+    val bannerFormat: BannerFormat,
     override val adUnit: AdUnit
 ) : AdAuctionParams {
     override val price: Double = adUnit.pricefloor
     val adUnitId: String? = adUnit.extra?.getString("ad_unit_id")
     val payload: String? = adUnit.extra?.optString("payload")
-    val bannerSize
-        get() = when (bannerFormat) {
-            BannerFormat.MRec,
-            BannerFormat.Banner,
-            BannerFormat.LeaderBoard -> bannerFormat
-            BannerFormat.Adaptive -> if (isTablet) BannerFormat.LeaderBoard else BannerFormat.Banner
-        }
 }

--- a/adapter/moloco/src/main/java/org/bidon/moloco/impl/MolocoBannerImpl.kt
+++ b/adapter/moloco/src/main/java/org/bidon/moloco/impl/MolocoBannerImpl.kt
@@ -89,7 +89,7 @@ internal class MolocoBannerImpl :
     }
 
     override fun load(adParams: MolocoBannerAuctionParams) {
-        logInfo(TAG, "Starting banner load with format: ${adParams.bannerSize}")
+        logInfo(TAG, "Starting banner load with format: ${adParams.bannerFormat}")
 
         val adUnitId = adParams.adUnitId
         if (adUnitId == null) {
@@ -114,8 +114,8 @@ internal class MolocoBannerImpl :
             return
         }
         Moloco.createBannerAd(
-            adParams.bannerSize,
-            adUnitId = adParams.adUnitId
+            adParams.bannerFormat,
+            adUnitId = adUnitId
         ) { banner: Banner?, adCreateError: Throwable? ->
             if (banner != null) {
                 bannerAd = banner

--- a/adapter/moloco/src/test/java/org/bidon/moloco/impl/MolocoBannerImplTest.kt
+++ b/adapter/moloco/src/test/java/org/bidon/moloco/impl/MolocoBannerImplTest.kt
@@ -1,10 +1,16 @@
 package org.bidon.moloco.impl
 
 import android.app.Activity
+import com.moloco.sdk.publisher.BannerAdSize
 import com.moloco.sdk.publisher.Moloco
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.slot
 import io.mockk.unmockkAll
+import io.mockk.verify
 import org.bidon.sdk.adapter.AdAuctionParamSource
 import org.bidon.sdk.ads.banner.BannerFormat
 import org.bidon.sdk.auction.models.AdUnit
@@ -111,6 +117,35 @@ class MolocoBannerImplTest {
         } catch (e: Exception) {
             assertTrue(true)
         }
+    }
+
+    @Test
+    fun `load adaptive banner should request anchored adaptive size`() {
+        val sizeSlot = slot<BannerAdSize>()
+        every {
+            Moloco.createMolocoBanner(any(), any(), capture(sizeSlot), any(), any())
+        } just Runs
+
+        val adParams = MolocoBannerAuctionParams(
+            bannerFormat = BannerFormat.Adaptive,
+            adUnit = AdUnit(
+                demandId = "moloco",
+                pricefloor = 2.5,
+                label = "test_label",
+                bidType = BidType.RTB,
+                ext = jsonObject {
+                    "ad_unit_id" hasValue "test_ad_unit_id"
+                    "payload" hasValue "test_payload"
+                }.toString(),
+                timeout = 5000,
+                uid = "test_uid"
+            )
+        )
+
+        testee.load(adParams)
+
+        verify { Moloco.createMolocoBanner(any(), "test_ad_unit_id", any(), any(), any()) }
+        assertTrue(sizeSlot.captured is BannerAdSize.AnchoredAdaptive)
     }
 
     @Test


### PR DESCRIPTION
Moloco SDK 4.10.0 introduced a real adaptive-banner API (createMolocoBanner + BannerAdSize). Wire BannerFormat.Adaptive to BannerAdSize.AnchoredAdaptive instead of resolving it to a fixed-size banner, so adaptive requests render a true anchored adaptive banner.

- Ext.createBannerAd: Adaptive branch now calls createMolocoBanner with AnchoredAdaptive (screen width in dp, null lets the SDK auto-detect); Banner/LeaderBoard/MRec keep their existing (non-deprecated) factories.
- MolocoBannerAuctionParams: expose raw bannerFormat, drop the resolver that mapped Adaptive to Banner/LeaderBoard.
- Bump adapter version to 4.10.0.1 and add a CHANGELOG entry.
- Add a test asserting the adaptive load requests an AnchoredAdaptive size.