### PR TITLE
⬆️ Update Applovin MAX adapter to 13.6.3

### DIFF
--- a/thirdPartyMediationAdapters/applovin_max/CHANGELOG.md
+++ b/thirdPartyMediationAdapters/applovin_max/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.14.0.0
+## Features:
+- Updated Applovin SDK to 13.6.3 for BCAMAX SDK
+
 # 0.13.0.0
 ## Features:
 - BDN-1045 Updated Applovin SDK to 13.5.1 for BCAMAX SDK

--- a/thirdPartyMediationAdapters/applovin_max/build.gradle.kts
+++ b/thirdPartyMediationAdapters/applovin_max/build.gradle.kts
@@ -21,6 +21,6 @@ android {
 dependencies {
     implementation(projects.bidon)
 
-    compileOnly("com.applovin:applovin-sdk:13.5.1")
-    testImplementation("com.applovin:applovin-sdk:13.5.1")
+    compileOnly("com.applovin:applovin-sdk:13.6.3")
+    testImplementation("com.applovin:applovin-sdk:13.6.3")
 }


### PR DESCRIPTION
## Summary
- Bump Applovin SDK `13.5.1` → `13.6.3` for BCAMAX
- Adapter version `0.14.0.0` (already set in `Versions.kt`)
- Add CHANGELOG entry

## Published
Artifact `com.applovin.mediation:bidon-adapter:0.14.0.0` published locally to `bidon-private` and `bidon` Artifactory repos.

## Test plan
- [x] `ktlintCheck`
- [x] `assembleRelease`
- [x] `testProductionReleaseUnitTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)