### PR TITLE
Feature/SDK-636: Pass BM Custom params from BidMachine bid into ad unit ext

### DIFF
--- a/adapter/bidmachine/CHANGELOG.md
+++ b/adapter/bidmachine/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [3.7.1.1] - 2026-08-11
 ### Changed
-- Relayed the bid response custom params to the ad unit ext reported in stats and auction info
+- Relayed the bid response custom params to the ad unit ext
 
 ## [3.7.1.0] - 2026-06-01
 ### Changed

--- a/adapter/bidmachine/CHANGELOG.md
+++ b/adapter/bidmachine/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 📋 [Release Notes](https://developers.bidmachine.io/sdk/general/android/android-changelog)
 
 ## [Unreleased]
+### Added
+- Relayed ML floor predictions from the bid response custom params into the ad unit ext reported in stats and auction info
 
 ## [3.7.1.0] - 2026-06-01
 ### Changed

--- a/adapter/bidmachine/CHANGELOG.md
+++ b/adapter/bidmachine/CHANGELOG.md
@@ -7,7 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 📋 [Release Notes](https://developers.bidmachine.io/sdk/general/android/android-changelog)
 
 ## [Unreleased]
-### Added
+
+## [3.7.1.1] - 2026-08-11
+### Changed
 - Relayed the bid response custom params to the ad unit ext reported in stats and auction info
 
 ## [3.7.1.0] - 2026-06-01

--- a/adapter/bidmachine/CHANGELOG.md
+++ b/adapter/bidmachine/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Added
-- Relayed ML floor predictions from the bid response custom params into the ad unit ext reported in stats and auction info
+- Relayed the bid response custom params to the ad unit ext reported in stats and auction info
 
 ## [3.7.1.0] - 2026-06-01
 ### Changed

--- a/adapter/bidmachine/build.gradle.kts
+++ b/adapter/bidmachine/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 val adapterSdkVersion = "3.7.1"
-val adapterMinor = 0
+val adapterMinor = 1
 val adapterSemantic = Versions.semanticVersion
 
 val adapterMainVersion = "$adapterSdkVersion.$adapterMinor$adapterSemantic"

--- a/adapter/bidmachine/src/main/java/org/bidon/bidmachine/ext/Ext.kt
+++ b/adapter/bidmachine/src/main/java/org/bidon/bidmachine/ext/Ext.kt
@@ -30,9 +30,7 @@ internal fun BannerFormat.toBannerAdSize(): BannerAdSize = when (this) {
     BannerFormat.Adaptive -> if (DeviceInfo.isTablet) BannerAdSize.Leaderboard else BannerAdSize.Banner
 }
 
-internal fun AdUnit.addMlFloorPredictions(auctionResult: BMAuctionResult) {
-    val predictions = auctionResult.customParams[MlFloorPredictionsKey] ?: return
-    extra?.put(MlFloorPredictionsKey, predictions)
+internal fun AdUnit.addCustomParams(auctionResult: BMAuctionResult) {
+    val extra = extra ?: return
+    auctionResult.customParams.forEach { (key, value) -> extra.put(key, value) }
 }
-
-private const val MlFloorPredictionsKey = "ml_floor_predictions"

--- a/adapter/bidmachine/src/main/java/org/bidon/bidmachine/ext/Ext.kt
+++ b/adapter/bidmachine/src/main/java/org/bidon/bidmachine/ext/Ext.kt
@@ -4,10 +4,12 @@ import io.bidmachine.AdContentType
 import io.bidmachine.AdPlacementConfig
 import io.bidmachine.BannerAdSize
 import io.bidmachine.BidMachine
+import org.bidon.bidmachine.BMAuctionResult
 import org.bidon.bidmachine.BuildConfig
 import org.bidon.sdk.ads.banner.BannerFormat
 import org.bidon.sdk.ads.banner.helper.DeviceInfo
 import org.bidon.sdk.auction.AdTypeParam
+import org.bidon.sdk.auction.models.AdUnit
 
 internal var adapterVersion = BuildConfig.ADAPTER_VERSION
 internal var sdkVersion = BidMachine.VERSION
@@ -27,3 +29,10 @@ internal fun BannerFormat.toBannerAdSize(): BannerAdSize = when (this) {
     BannerFormat.MRec -> BannerAdSize.MediumRectangle
     BannerFormat.Adaptive -> if (DeviceInfo.isTablet) BannerAdSize.Leaderboard else BannerAdSize.Banner
 }
+
+internal fun AdUnit.addMlFloorPredictions(auctionResult: BMAuctionResult) {
+    val predictions = auctionResult.customParams[MlFloorPredictionsKey] ?: return
+    extra?.put(MlFloorPredictionsKey, predictions)
+}
+
+private const val MlFloorPredictionsKey = "ml_floor_predictions"

--- a/adapter/bidmachine/src/main/java/org/bidon/bidmachine/impl/BMBannerAdImpl.kt
+++ b/adapter/bidmachine/src/main/java/org/bidon/bidmachine/impl/BMBannerAdImpl.kt
@@ -11,7 +11,7 @@ import org.bidon.bidmachine.BMAuctionResult
 import org.bidon.bidmachine.BMBannerAuctionParams
 import org.bidon.bidmachine.asBidonErrorOnBid
 import org.bidon.bidmachine.asBidonErrorOnFill
-import org.bidon.bidmachine.ext.addMlFloorPredictions
+import org.bidon.bidmachine.ext.addCustomParams
 import org.bidon.bidmachine.ext.asBidonAdValue
 import org.bidon.bidmachine.ext.toBannerAdSize
 import org.bidon.sdk.adapter.AdAuctionParamSource
@@ -85,7 +85,7 @@ internal class BMBannerAdImpl(
                     object : AdRequest.AdRequestListener<BannerRequest> {
                         override fun onRequestSuccess(request: BannerRequest, result: BMAuctionResult) {
                             logInfo(TAG, "onRequestSuccess $result: $this")
-                            adParams.adUnit.addMlFloorPredictions(result)
+                            adParams.adUnit.addCustomParams(result)
                             fillRequest(request, bidType)
                         }
 

--- a/adapter/bidmachine/src/main/java/org/bidon/bidmachine/impl/BMBannerAdImpl.kt
+++ b/adapter/bidmachine/src/main/java/org/bidon/bidmachine/impl/BMBannerAdImpl.kt
@@ -11,6 +11,7 @@ import org.bidon.bidmachine.BMAuctionResult
 import org.bidon.bidmachine.BMBannerAuctionParams
 import org.bidon.bidmachine.asBidonErrorOnBid
 import org.bidon.bidmachine.asBidonErrorOnFill
+import org.bidon.bidmachine.ext.addMlFloorPredictions
 import org.bidon.bidmachine.ext.asBidonAdValue
 import org.bidon.bidmachine.ext.toBannerAdSize
 import org.bidon.sdk.adapter.AdAuctionParamSource
@@ -84,6 +85,7 @@ internal class BMBannerAdImpl(
                     object : AdRequest.AdRequestListener<BannerRequest> {
                         override fun onRequestSuccess(request: BannerRequest, result: BMAuctionResult) {
                             logInfo(TAG, "onRequestSuccess $result: $this")
+                            adParams.adUnit.addMlFloorPredictions(result)
                             fillRequest(request, bidType)
                         }
 

--- a/adapter/bidmachine/src/main/java/org/bidon/bidmachine/impl/BMInterstitialAdImpl.kt
+++ b/adapter/bidmachine/src/main/java/org/bidon/bidmachine/impl/BMInterstitialAdImpl.kt
@@ -14,6 +14,7 @@ import org.bidon.bidmachine.BMAuctionResult
 import org.bidon.bidmachine.BMFullscreenAuctionParams
 import org.bidon.bidmachine.asBidonErrorOnBid
 import org.bidon.bidmachine.asBidonErrorOnFill
+import org.bidon.bidmachine.ext.addMlFloorPredictions
 import org.bidon.bidmachine.ext.asBidonAdValue
 import org.bidon.sdk.adapter.AdAuctionParamSource
 import org.bidon.sdk.adapter.AdAuctionParams
@@ -91,6 +92,7 @@ internal class BMInterstitialAdImpl(
                         result: BMAuctionResult
                     ) {
                         logInfo(TAG, "onRequestSuccess $result: $this")
+                        adParams.adUnit.addMlFloorPredictions(result)
                         fillRequest(request, bidType)
                     }
 

--- a/adapter/bidmachine/src/main/java/org/bidon/bidmachine/impl/BMInterstitialAdImpl.kt
+++ b/adapter/bidmachine/src/main/java/org/bidon/bidmachine/impl/BMInterstitialAdImpl.kt
@@ -14,7 +14,7 @@ import org.bidon.bidmachine.BMAuctionResult
 import org.bidon.bidmachine.BMFullscreenAuctionParams
 import org.bidon.bidmachine.asBidonErrorOnBid
 import org.bidon.bidmachine.asBidonErrorOnFill
-import org.bidon.bidmachine.ext.addMlFloorPredictions
+import org.bidon.bidmachine.ext.addCustomParams
 import org.bidon.bidmachine.ext.asBidonAdValue
 import org.bidon.sdk.adapter.AdAuctionParamSource
 import org.bidon.sdk.adapter.AdAuctionParams
@@ -92,7 +92,7 @@ internal class BMInterstitialAdImpl(
                         result: BMAuctionResult
                     ) {
                         logInfo(TAG, "onRequestSuccess $result: $this")
-                        adParams.adUnit.addMlFloorPredictions(result)
+                        adParams.adUnit.addCustomParams(result)
                         fillRequest(request, bidType)
                     }
 

--- a/adapter/bidmachine/src/main/java/org/bidon/bidmachine/impl/BMRewardedAdImpl.kt
+++ b/adapter/bidmachine/src/main/java/org/bidon/bidmachine/impl/BMRewardedAdImpl.kt
@@ -14,7 +14,7 @@ import org.bidon.bidmachine.BMAuctionResult
 import org.bidon.bidmachine.BMFullscreenAuctionParams
 import org.bidon.bidmachine.asBidonErrorOnBid
 import org.bidon.bidmachine.asBidonErrorOnFill
-import org.bidon.bidmachine.ext.addMlFloorPredictions
+import org.bidon.bidmachine.ext.addCustomParams
 import org.bidon.bidmachine.ext.asBidonAdValue
 import org.bidon.sdk.adapter.AdAuctionParamSource
 import org.bidon.sdk.adapter.AdAuctionParams
@@ -92,7 +92,7 @@ internal class BMRewardedAdImpl(
                         result: BMAuctionResult
                     ) {
                         logInfo(TAG, "onRequestSuccess $result: $this")
-                        adParams.adUnit.addMlFloorPredictions(result)
+                        adParams.adUnit.addCustomParams(result)
                         fillAd(request, bidType)
                     }
 

--- a/adapter/bidmachine/src/main/java/org/bidon/bidmachine/impl/BMRewardedAdImpl.kt
+++ b/adapter/bidmachine/src/main/java/org/bidon/bidmachine/impl/BMRewardedAdImpl.kt
@@ -14,6 +14,7 @@ import org.bidon.bidmachine.BMAuctionResult
 import org.bidon.bidmachine.BMFullscreenAuctionParams
 import org.bidon.bidmachine.asBidonErrorOnBid
 import org.bidon.bidmachine.asBidonErrorOnFill
+import org.bidon.bidmachine.ext.addMlFloorPredictions
 import org.bidon.bidmachine.ext.asBidonAdValue
 import org.bidon.sdk.adapter.AdAuctionParamSource
 import org.bidon.sdk.adapter.AdAuctionParams
@@ -91,6 +92,7 @@ internal class BMRewardedAdImpl(
                         result: BMAuctionResult
                     ) {
                         logInfo(TAG, "onRequestSuccess $result: $this")
+                        adParams.adUnit.addMlFloorPredictions(result)
                         fillAd(request, bidType)
                     }
 

--- a/adapter/bidmachine/src/test/java/org/bidon/bidmachine/ext/ExtTest.kt
+++ b/adapter/bidmachine/src/test/java/org/bidon/bidmachine/ext/ExtTest.kt
@@ -1,0 +1,70 @@
+package org.bidon.bidmachine.ext
+
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import org.bidon.bidmachine.BMAuctionResult
+import org.bidon.sdk.auction.models.AdUnit
+import org.bidon.sdk.stats.impl.StatisticsCollectorImpl
+import org.bidon.sdk.stats.models.BidType
+import org.bidon.sdk.utils.json.jsonObject
+import org.junit.Test
+
+class ExtTest {
+
+    @Test
+    fun `relay ml floor predictions into ad unit ext`() {
+        val adUnit = createAdUnit(serverExt = jsonObject { "payload" hasValue "payload123" }.toString())
+
+        adUnit.addMlFloorPredictions(bidWith("ml_floor_predictions" to Predictions))
+
+        assertThat(adUnit.extra?.getString("ml_floor_predictions")).isEqualTo(Predictions)
+        assertThat(adUnit.extra?.getString("payload")).isEqualTo("payload123")
+    }
+
+    @Test
+    fun `keep ad unit ext untouched when bid carries no predictions`() {
+        val adUnit = createAdUnit(serverExt = jsonObject { "payload" hasValue "payload123" }.toString())
+
+        adUnit.addMlFloorPredictions(bidWith("other_param" to "value123"))
+
+        assertThat(adUnit.extra?.has("ml_floor_predictions")).isFalse()
+        assertThat(adUnit.extra?.getString("payload")).isEqualTo("payload123")
+    }
+
+    @Test
+    fun `relay predictions into the ad unit already captured by the stats row`() {
+        val adUnit = createAdUnit(serverExt = jsonObject { "payload" hasValue "payload123" }.toString())
+        val statisticsCollector = StatisticsCollectorImpl().apply { markFillStarted(adUnit, 2.75) }
+
+        adUnit.addMlFloorPredictions(bidWith("ml_floor_predictions" to Predictions))
+
+        assertThat(statisticsCollector.getStats().adUnit?.extra?.getString("ml_floor_predictions"))
+            .isEqualTo(Predictions)
+    }
+
+    @Test
+    fun `skip predictions when ad unit came without ext`() {
+        val adUnit = createAdUnit(serverExt = null)
+
+        adUnit.addMlFloorPredictions(bidWith("ml_floor_predictions" to Predictions))
+
+        assertThat(adUnit.extra).isNull()
+    }
+
+    private fun bidWith(vararg customParams: Pair<String, String>) = mockk<BMAuctionResult> {
+        every { this@mockk.customParams } returns mapOf(*customParams)
+    }
+
+    private fun createAdUnit(serverExt: String?) = AdUnit(
+        demandId = "bidmachine",
+        label = "label123",
+        pricefloor = 2.75,
+        uid = "uid123",
+        bidType = BidType.RTB,
+        timeout = 5000,
+        ext = serverExt,
+    )
+}
+
+private const val Predictions = """[{"ecpm":1.2,"probability":0.8}]"""

--- a/adapter/bidmachine/src/test/java/org/bidon/bidmachine/ext/ExtTest.kt
+++ b/adapter/bidmachine/src/test/java/org/bidon/bidmachine/ext/ExtTest.kt
@@ -18,13 +18,13 @@ class ExtTest {
 
         adUnit.addCustomParams(
             bidWith(
-                "ml_floor_predictions" to Predictions,
-                "some_param" to "value123",
+                "custom_param" to "custom123",
+                "another_param" to "another123",
             )
         )
 
-        assertThat(adUnit.extra?.getString("ml_floor_predictions")).isEqualTo(Predictions)
-        assertThat(adUnit.extra?.getString("some_param")).isEqualTo("value123")
+        assertThat(adUnit.extra?.getString("custom_param")).isEqualTo("custom123")
+        assertThat(adUnit.extra?.getString("another_param")).isEqualTo("another123")
         assertThat(adUnit.extra?.getString("payload")).isEqualTo("payload123")
     }
 
@@ -43,17 +43,17 @@ class ExtTest {
         val adUnit = createAdUnit(serverExt = serverExt)
         val statisticsCollector = StatisticsCollectorImpl().apply { markFillStarted(adUnit, 2.75) }
 
-        adUnit.addCustomParams(bidWith("ml_floor_predictions" to Predictions))
+        adUnit.addCustomParams(bidWith("custom_param" to "custom123"))
 
-        assertThat(statisticsCollector.getStats().adUnit?.extra?.getString("ml_floor_predictions"))
-            .isEqualTo(Predictions)
+        assertThat(statisticsCollector.getStats().adUnit?.extra?.getString("custom_param"))
+            .isEqualTo("custom123")
     }
 
     @Test
     fun `skip custom params when ad unit came without ext`() {
         val adUnit = createAdUnit(serverExt = null)
 
-        adUnit.addCustomParams(bidWith("ml_floor_predictions" to Predictions))
+        adUnit.addCustomParams(bidWith("custom_param" to "custom123"))
 
         assertThat(adUnit.extra).isNull()
     }
@@ -74,4 +74,3 @@ class ExtTest {
 }
 
 private val serverExt = jsonObject { "payload" hasValue "payload123" }.toString()
-private const val Predictions = """[{"ecpm":1.2,"probability":0.8}]"""

--- a/adapter/bidmachine/src/test/java/org/bidon/bidmachine/ext/ExtTest.kt
+++ b/adapter/bidmachine/src/test/java/org/bidon/bidmachine/ext/ExtTest.kt
@@ -13,41 +13,47 @@ import org.junit.Test
 class ExtTest {
 
     @Test
-    fun `relay ml floor predictions into ad unit ext`() {
-        val adUnit = createAdUnit(serverExt = jsonObject { "payload" hasValue "payload123" }.toString())
+    fun `relay all bid response custom params into ad unit ext`() {
+        val adUnit = createAdUnit(serverExt = serverExt)
 
-        adUnit.addMlFloorPredictions(bidWith("ml_floor_predictions" to Predictions))
+        adUnit.addCustomParams(
+            bidWith(
+                "ml_floor_predictions" to Predictions,
+                "some_param" to "value123",
+            )
+        )
 
         assertThat(adUnit.extra?.getString("ml_floor_predictions")).isEqualTo(Predictions)
+        assertThat(adUnit.extra?.getString("some_param")).isEqualTo("value123")
         assertThat(adUnit.extra?.getString("payload")).isEqualTo("payload123")
     }
 
     @Test
-    fun `keep ad unit ext untouched when bid carries no predictions`() {
-        val adUnit = createAdUnit(serverExt = jsonObject { "payload" hasValue "payload123" }.toString())
+    fun `keep ad unit ext untouched when bid carries no custom params`() {
+        val adUnit = createAdUnit(serverExt = serverExt)
 
-        adUnit.addMlFloorPredictions(bidWith("other_param" to "value123"))
+        adUnit.addCustomParams(bidWith())
 
-        assertThat(adUnit.extra?.has("ml_floor_predictions")).isFalse()
+        assertThat(adUnit.extra?.length()).isEqualTo(1)
         assertThat(adUnit.extra?.getString("payload")).isEqualTo("payload123")
     }
 
     @Test
-    fun `relay predictions into the ad unit already captured by the stats row`() {
-        val adUnit = createAdUnit(serverExt = jsonObject { "payload" hasValue "payload123" }.toString())
+    fun `relay custom params into the ad unit already captured by the stats row`() {
+        val adUnit = createAdUnit(serverExt = serverExt)
         val statisticsCollector = StatisticsCollectorImpl().apply { markFillStarted(adUnit, 2.75) }
 
-        adUnit.addMlFloorPredictions(bidWith("ml_floor_predictions" to Predictions))
+        adUnit.addCustomParams(bidWith("ml_floor_predictions" to Predictions))
 
         assertThat(statisticsCollector.getStats().adUnit?.extra?.getString("ml_floor_predictions"))
             .isEqualTo(Predictions)
     }
 
     @Test
-    fun `skip predictions when ad unit came without ext`() {
+    fun `skip custom params when ad unit came without ext`() {
         val adUnit = createAdUnit(serverExt = null)
 
-        adUnit.addMlFloorPredictions(bidWith("ml_floor_predictions" to Predictions))
+        adUnit.addCustomParams(bidWith("ml_floor_predictions" to Predictions))
 
         assertThat(adUnit.extra).isNull()
     }
@@ -67,4 +73,5 @@ class ExtTest {
     )
 }
 
+private val serverExt = jsonObject { "payload" hasValue "payload123" }.toString()
 private const val Predictions = """[{"ecpm":1.2,"probability":0.8}]"""

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,6 +33,7 @@ dependencyResolutionManagement {
         maven(url = "https://cboost.jfrog.io/artifactory/chartboost-ads") {
             content {
                 includeGroup("com.chartboost")
+                includeGroupByRegex("com\\.iab\\.omid\\.library.*")
             }
         }
         maven(url = "https://cboost.jfrog.io/artifactory/chartboost-mediation") {


### PR DESCRIPTION
Read ml_floor_predictions from the bid response custom params and write it into the server-provided ad unit ext, which the core SDK already reports in /stats and exposes via AuctionInfo -> Appodeal credentials -> /report. No core SDK change, so no SDK release is required.

Hooked on the bid callback instead of the fill callback so the predictions also reach the stats row when the bid wins but the fill fails.

SDK-636: Remove redundant comment

SDK-636: Cover that relayed predictions reach the captured stats ad unit

SDK-636: Align the relay helper with adapter conventions

Rename the key constant to PascalCase, which is the prevailing style outside the CODE_* vendor-error clusters, and drop the TAG/logging from ext/Ext.kt — no other adapter's Ext.kt logs. Document why the relay runs on bid success rather than on fill, since every other auctionResult read here is in onAdLoaded.