### PR TITLE
Feature/SDK-636: Resolve vendor SDKs from vendor repositories after Bidon Art…

### DIFF
--- a/.github/workflows/release-adapter.yml
+++ b/.github/workflows/release-adapter.yml
@@ -77,6 +77,7 @@ jobs:
           echo "🎯 Repository: ${{ inputs.repository }}"
 
       - name: Publish to Artifactory (primary)
+        continue-on-error: true
         run: |
           echo "🚀 Publishing ${{ inputs.adapter }} to ${{ inputs.repository }} (primary)..."
           ./gradlew :adapter:${{ inputs.adapter }}:publishAllPublicationsToBidonRepository --no-daemon

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -67,6 +67,7 @@ jobs:
         run: rm -rf */build build-logic/build build-logic/convention-plugins/build
 
       - name: Publish to Artifactory (primary)
+        continue-on-error: true
         run: ./gradlew publishAllPublicationsToBidonRepository
         env:
           ORG_GRADLE_PROJECT_repo: ${{ github.event.inputs.ORG_GRADLE_PROJECT_repo }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 0.15.0 (2026.*.*)
+## Features:
 - BDN-1192 Fixed in-flight ad source leak when destroyAd() is called during an auction
+- SDK-636 Resolved vendor SDKs from vendor repositories after the Bidon Artifactory sunset
 
 # 0.14.0 (2026.06.10)
 ## Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # 0.15.0 (2026.*.*)
-## Features:
 - BDN-1192 Fixed in-flight ad source leak when destroyAd() is called during an auction
-- SDK-636 Resolved vendor SDKs from vendor repositories after the Bidon Artifactory sunset
 
 # 0.14.0 (2026.06.10)
 ## Features:

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,6 +23,23 @@ dependencyResolutionManagement {
         // mavenLocal()
         mavenCentral()
         maven(url = "https://artifactory.bidon.org/bidon")
+        maven(url = "https://artifactory.bidmachine.io/bidmachine") {
+            content {
+                includeGroupByRegex("io\\.bidmachine.*")
+                includeGroupByRegex("com\\.explorestack.*")
+                includeGroup("com.mbridge.msdk.oversea")
+            }
+        }
+        maven(url = "https://cboost.jfrog.io/artifactory/chartboost-ads") {
+            content {
+                includeGroup("com.chartboost")
+            }
+        }
+        maven(url = "https://cboost.jfrog.io/artifactory/chartboost-mediation") {
+            content {
+                includeGroup("com.chartboost")
+            }
+        }
         maven(url = "https://artifactory.bidon.org/artifactory/bidon-private/") {
             credentials {
                 username = System.getenv("BDN_USERNAME")


### PR DESCRIPTION
…ifactory sunset

artifactory.bidon.org/bidon redirects to the migrated Bidon repository, which carries only org.bidon artifacts — the vendor SDK mirrors it used to proxy are gone. Adapter builds needing a vendor SDK absent from Maven Central (io.bidmachine, com.chartboost, com.mbridge) stopped resolving.

Take those from the vendors' own public repositories instead, and let the publish job continue to the fallback Artifactory when the primary target (the sunset host) is unreachable.